### PR TITLE
 Add inspiration proposal system for collaborators

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -25,6 +25,7 @@ import inspirationRouter from "./src/server/routes/inspiration.routes";
 import mementosRouter from "./src/server/routes/mementos.routes";
 import { analyticsPublicRouter, analyticsAdminRouter } from "./src/server/routes/analytics.routes";
 import moderationRouter from "./src/server/routes/moderation.routes";
+import inspirationProposalsRouter from "./src/server/routes/inspiration-proposals.routes";
 import monitoringRouter from "./src/server/routes/monitoring.routes";
 import { startMementosCron } from "./src/server/cron/mementos.cron";
 import { startAnalyticsCron } from "./src/server/cron/analytics.cron";
@@ -130,6 +131,7 @@ async function createServer() {
   app.use("/api/analytics", analyticsPublicRouter);
   app.use(API_ROUTE_PREFIXES.admin, analyticsAdminRouter);
   app.use("/api/moderare", moderationRouter);
+  app.use("/api/inspiration-proposals", inspirationProposalsRouter);
   app.use("/api/monitoring", monitoringRouter);
   app.use("/api/admin/monitoring", monitoringRouter);
 

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -26,12 +26,13 @@ import GoalDetailPage from "./features/admin/components/GoalDetailPage";
 import BankDetailsPage from "./features/admin/components/BankDetailsPage";
 import ModerationReviewPage from "./features/admin/components/Moderation/ModerationReviewPage";
 import ErrorsPage from "./features/admin/components/ErrorsPage";
+import CollaboratorPage from "./features/collaborator/CollaboratorPage";
 import RevinPage from "./pages/Revin/RevinPage";
 import { usePageTracking } from "./hooks/usePageTracking";
 import { useClientErrorReporting } from "./hooks/useClientErrorReporting";
 
 
-const HIDE_CHAT_PREFIXES = ["/admin", "/login", "/media", "/contract", "/revin"];
+const HIDE_CHAT_PREFIXES = ["/admin", "/login", "/media", "/contract", "/revin", "/colaborator"];
 
 export const App = () => {
   const location = useLocation();
@@ -102,6 +103,7 @@ export const App = () => {
             <Route path="/admin/goals/:type" element={<GoalDetailPage />} />
             <Route path="/admin/moderare" element={<ModerationReviewPage />} />
             <Route path="/admin/errors" element={<ErrorsPage />} />
+            <Route path="/colaborator" element={<CollaboratorPage />} />
           </Route>
 
 

--- a/src/client/features/admin/components/AddLeadModal.tsx
+++ b/src/client/features/admin/components/AddLeadModal.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import type { ClientEvent, EventType } from "../types";
+import { useBodyScrollLock } from "../../../hooks/useBodyScrollLock";
 
 interface Props {
   onClose: () => void;
@@ -13,6 +14,7 @@ const inputClass =
 const labelClass = "block text-neutral-400 text-xs font-medium mb-1 uppercase tracking-wide";
 
 const AddLeadModal: React.FC<Props> = ({ onClose, onAdded }) => {
+  useBodyScrollLock(true);
   const [form, setForm] = useState({
     fullName: "",
     phone: "",

--- a/src/client/features/admin/components/ConfirmModal.tsx
+++ b/src/client/features/admin/components/ConfirmModal.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { useBodyScrollLock } from "../../../hooks/useBodyScrollLock";
 
 interface ConfirmModalProps {
   title: string;
@@ -25,6 +26,7 @@ const ConfirmModal: React.FC<ConfirmModalProps> = ({
   onConfirm,
   onCancel,
 }) => {
+  useBodyScrollLock(true);
   return (
     <div
       className="fixed inset-0 bg-black/75 backdrop-blur-sm flex items-center justify-center z-[60] px-4"

--- a/src/client/features/admin/components/Dashboard/index.tsx
+++ b/src/client/features/admin/components/Dashboard/index.tsx
@@ -86,6 +86,7 @@ const Dashboard: React.FC = () => {
   const [urgentMementos, setUrgentMementos] = useState(0);
   const [pendingModerationCount, setPendingModerationCount] = useState(0);
   const [unseenErrorsCount, setUnseenErrorsCount] = useState(0);
+  const [pendingProposalsCount, setPendingProposalsCount] = useState(0);
 
   useEffect(() => {
     const meta = document.createElement("meta");
@@ -135,6 +136,13 @@ const Dashboard: React.FC = () => {
       })
         .then((r) => r.json())
         .then((d: { pendingCount?: number }) => setPendingModerationCount(d.pendingCount ?? 0))
+        .catch(() => {});
+
+      fetch("/api/inspiration-proposals/admin/pending-count", {
+        headers: { Authorization: `Bearer ${auth.accessToken}` },
+      })
+        .then((r) => r.json())
+        .then((d: { pendingCount?: number }) => setPendingProposalsCount(d.pendingCount ?? 0))
         .catch(() => {});
     }
 
@@ -269,6 +277,11 @@ const Dashboard: React.FC = () => {
               <polyline points="21 15 16 10 5 21" />
             </svg>
             Inspirație
+            {pendingProposalsCount > 0 && (
+              <span className="ml-1 px-1.5 py-0.5 rounded-full text-xs font-semibold bg-amber-500 text-white leading-none">
+                {pendingProposalsCount}
+              </span>
+            )}
           </button>
           <button
             onClick={() => navigate("/admin/mementos")}

--- a/src/client/features/admin/components/EventCard.tsx
+++ b/src/client/features/admin/components/EventCard.tsx
@@ -6,6 +6,7 @@ import FileDropZone from "./FileDropZone";
 import MultiFileDropZone from "./MultiFileDropZone";
 import ConfirmModal from "./ConfirmModal";
 import { slugify } from "../../../utils/slugify";
+import { useBodyScrollLock } from "../../../hooks/useBodyScrollLock";
 
 interface EventCardProps {
   event: ClientEvent;
@@ -32,6 +33,7 @@ const EventCard: React.FC<EventCardProps> = ({ event, initialCollapsed = false, 
 
   const [collapsed, setCollapsed] = useState(initialCollapsed);
   const [editing, setEditing] = useState(false);
+  useBodyScrollLock(editing);
   const [saving, setSaving] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
   const [quickSaving, setQuickSaving] = useState(false);

--- a/src/client/features/admin/components/InspirationPage.tsx
+++ b/src/client/features/admin/components/InspirationPage.tsx
@@ -1,8 +1,10 @@
 import React, { useEffect, useRef, useState, useCallback } from "react";
+import { useBodyScrollLock } from "../../../hooks/useBodyScrollLock";
 import { useNavigate } from "react-router-dom";
 import { ref, uploadBytesResumable, getDownloadURL, deleteObject } from "firebase/storage";
 import { storage } from "../../../firebase";
 import AncaLoader from "../../../components/UI/AncaLoader";
+import useAuth from "../auth/useAuth";
 
 interface InspirationPhoto {
   id: string;
@@ -10,6 +12,15 @@ interface InspirationPhoto {
   tags: string[];
   notes?: string;
   uploadedAt: string;
+}
+
+interface InspirationProposal {
+  id: string;
+  url: string;
+  tags: string[];
+  notes: string;
+  proposedByEmail: string;
+  proposedAt: string;
 }
 
 
@@ -87,8 +98,12 @@ function TagPill({
   );
 }
 
+type AdminTab = "gallery" | "proposals";
+
 export default function InspirationPage() {
   const navigate = useNavigate();
+  const { auth } = useAuth();
+  const [adminTab, setAdminTab] = useState<AdminTab>("gallery");
   const [photos, setPhotos] = useState<InspirationPhoto[]>([]);
   const [loading, setLoading] = useState(true);
   const [filterTags, setFilterTags] = useState<string[]>([]);
@@ -99,6 +114,10 @@ export default function InspirationPage() {
   const [showDebug, setShowDebug] = useState(false);
   const [preview, setPreview] = useState<InspirationPhoto | null>(null);
   const [showUpload, setShowUpload] = useState(false);
+  const [proposals, setProposals] = useState<InspirationProposal[]>([]);
+  const [proposalsLoading, setProposalsLoading] = useState(false);
+  const [proposalsFetched, setProposalsFetched] = useState(false);
+  useBodyScrollLock(preview !== null || showUpload);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
@@ -186,6 +205,26 @@ export default function InspirationPage() {
   const handleAdded = (photo: InspirationPhoto) =>
     setPhotos((prev) => [photo, ...prev]);
 
+  const loadProposals = useCallback(() => {
+    if (!auth.accessToken) return;
+    setProposalsLoading(true);
+    fetch("/api/inspiration-proposals/admin/pending", {
+      headers: { Authorization: `Bearer ${auth.accessToken}` },
+    })
+      .then((response) => response.json())
+      .then((data: { proposals?: InspirationProposal[] }) => {
+        setProposals(data.proposals ?? []);
+        setProposalsFetched(true);
+      })
+      .finally(() => setProposalsLoading(false));
+  }, [auth.accessToken]);
+
+  useEffect(() => {
+    if (adminTab === "proposals" && !proposalsFetched) {
+      loadProposals();
+    }
+  }, [adminTab, proposalsFetched, loadProposals]);
+
   if (loading) return <AncaLoader />;
 
   return (
@@ -210,16 +249,56 @@ export default function InspirationPage() {
             <h1 className="text-white text-2xl font-light tracking-tight">Inspirație Foto</h1>
             <p className="text-neutral-500 text-sm mt-1">{photos.length} poze · {filtered.length} afișate</p>
           </div>
+          {adminTab === "gallery" && (
+            <button
+              onClick={() => setShowUpload(true)}
+              className="flex items-center gap-2 px-4 py-2 rounded-xl bg-violet-600 text-white text-sm font-medium hover:bg-violet-500 transition-colors"
+            >
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+                <line x1="12" y1="5" x2="12" y2="19" /><line x1="5" y1="12" x2="19" y2="12" />
+              </svg>
+              Adaugă poză
+            </button>
+          )}
+        </div>
+
+        {/* Admin tabs */}
+        <div className="flex gap-1 bg-neutral-900 border border-neutral-800 rounded-xl p-1">
           <button
-            onClick={() => setShowUpload(true)}
-            className="flex items-center gap-2 px-4 py-2 rounded-xl bg-violet-600 text-white text-sm font-medium hover:bg-violet-500 transition-colors"
+            onClick={() => setAdminTab("gallery")}
+            className={`flex-1 py-2 px-3 rounded-lg text-sm font-medium transition-colors ${
+              adminTab === "gallery" ? "bg-violet-600 text-white" : "text-neutral-400 hover:text-white"
+            }`}
           >
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
-              <line x1="12" y1="5" x2="12" y2="19" /><line x1="5" y1="12" x2="19" y2="12" />
-            </svg>
-            Adaugă poză
+            Galerie
+          </button>
+          <button
+            onClick={() => setAdminTab("proposals")}
+            className={`flex-1 py-2 px-3 rounded-lg text-sm font-medium transition-colors flex items-center justify-center gap-2 ${
+              adminTab === "proposals" ? "bg-violet-600 text-white" : "text-neutral-400 hover:text-white"
+            }`}
+          >
+            Propuneri
+            {proposals.length > 0 && (
+              <span className="px-1.5 py-0.5 rounded-full bg-amber-500/30 text-amber-400 text-xs font-semibold">
+                {proposals.length}
+              </span>
+            )}
           </button>
         </div>
+
+        {adminTab === "proposals" && (
+          <ProposalsPanel
+            proposals={proposals}
+            loading={proposalsLoading}
+            token={auth.accessToken}
+            onReviewed={(reviewedId) => {
+              setProposals((previous) => previous.filter((proposal) => proposal.id !== reviewedId));
+            }}
+          />
+        )}
+
+        {adminTab === "gallery" && <>
 
         {/* Search */}
         <div className="bg-neutral-900 border border-neutral-800 rounded-xl p-4">
@@ -358,6 +437,8 @@ export default function InspirationPage() {
             ))}
           </div>
         )}
+
+        </>}
       </div>
 
       {/* Fullscreen preview */}
@@ -379,7 +460,7 @@ export default function InspirationPage() {
       {showUpload && (
         <UploadModal
           onClose={() => setShowUpload(false)}
-          onAdded={(photo) => { handleAdded(photo); setShowUpload(false); }}
+          onAdded={handleAdded}
         />
       )}
     </div>
@@ -666,6 +747,180 @@ function PreviewModal({
   );
 }
 
+function ProposalsPanel({
+  proposals,
+  loading,
+  token,
+  onReviewed,
+}: {
+  proposals: InspirationProposal[];
+  loading: boolean;
+  token: string;
+  onReviewed: (id: string) => void;
+}) {
+  const [rejectingId, setRejectingId] = useState<string | null>(null);
+  const [rejectReason, setRejectReason] = useState("");
+  const [processingId, setProcessingId] = useState<string | null>(null);
+
+  const review = async (id: string, action: "approve" | "reject", reason?: string) => {
+    setProcessingId(id);
+    try {
+      await fetch(`/api/inspiration-proposals/admin/review/${id}`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ action, rejectionReason: reason ?? "" }),
+      });
+      onReviewed(id);
+    } finally {
+      setProcessingId(null);
+      setRejectingId(null);
+      setRejectReason("");
+    }
+  };
+
+  if (loading) {
+    return <p className="text-neutral-600 text-sm text-center py-10">Se încarcă propunerile...</p>;
+  }
+
+  if (proposals.length === 0) {
+    return (
+      <div className="text-center py-16">
+        <p className="text-neutral-500 text-sm">Nicio propunere în așteptare.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <p className="text-neutral-500 text-sm">{proposals.length} propuneri în așteptare</p>
+      {proposals.map((proposal) => (
+        <div key={proposal.id} className="bg-neutral-900 border border-neutral-800 rounded-xl overflow-hidden">
+          <div className="flex gap-4 p-4">
+            <img
+              src={proposal.url}
+              alt=""
+              className="w-28 h-28 rounded-lg object-cover shrink-0"
+            />
+            <div className="min-w-0 flex-1 space-y-2">
+              <div>
+                <p className="text-white text-sm font-medium truncate">{proposal.proposedByEmail}</p>
+                <p className="text-neutral-500 text-xs">
+                  {new Date(proposal.proposedAt).toLocaleDateString("ro-RO", { day: "numeric", month: "short", year: "numeric" })}
+                </p>
+              </div>
+              {proposal.tags.length > 0 && (
+                <div className="flex flex-wrap gap-1">
+                  {proposal.tags.slice(0, 5).map((tag) => (
+                    <span key={tag} className="px-1.5 py-0.5 rounded-full bg-violet-500/20 text-violet-300 text-xs">
+                      {tag}
+                    </span>
+                  ))}
+                  {proposal.tags.length > 5 && (
+                    <span className="text-neutral-500 text-xs">+{proposal.tags.length - 5}</span>
+                  )}
+                </div>
+              )}
+              {proposal.notes && (
+                <p className="text-neutral-400 text-xs italic">"{proposal.notes}"</p>
+              )}
+            </div>
+          </div>
+
+          {rejectingId === proposal.id ? (
+            <div className="px-4 pb-4 space-y-2 border-t border-neutral-800 pt-3">
+              <p className="text-neutral-400 text-xs">Motiv respingere (opțional):</p>
+              <textarea
+                className="w-full bg-neutral-800 text-white text-sm border border-neutral-700 rounded-lg px-3 py-2 outline-none focus:border-red-500 transition-colors resize-none placeholder-neutral-600"
+                rows={2}
+                placeholder="ex: calitate slabă, nu se potrivește stilului..."
+                value={rejectReason}
+                onChange={(event) => setRejectReason(event.target.value)}
+              />
+              <div className="flex gap-2">
+                <button
+                  onClick={() => { setRejectingId(null); setRejectReason(""); }}
+                  className="flex-1 px-3 py-2 rounded-lg border border-neutral-700 text-neutral-400 text-xs hover:border-neutral-500 transition-colors"
+                >
+                  Anulează
+                </button>
+                <button
+                  onClick={() => review(proposal.id, "reject", rejectReason)}
+                  disabled={processingId === proposal.id}
+                  className="flex-1 px-3 py-2 rounded-lg bg-red-500/20 text-red-400 text-xs font-medium hover:bg-red-500/30 disabled:opacity-40 transition-colors"
+                >
+                  {processingId === proposal.id ? "Se procesează..." : "Confirmă respingerea"}
+                </button>
+              </div>
+            </div>
+          ) : (
+            <div className="flex gap-2 px-4 pb-4 border-t border-neutral-800 pt-3">
+              <button
+                onClick={() => review(proposal.id, "approve")}
+                disabled={processingId === proposal.id}
+                className="flex-1 px-4 py-2 rounded-lg bg-emerald-500/20 text-emerald-400 text-sm font-medium hover:bg-emerald-500/30 disabled:opacity-40 transition-colors"
+              >
+                {processingId === proposal.id ? "..." : "✓ Acceptă"}
+              </button>
+              <button
+                onClick={() => setRejectingId(proposal.id)}
+                disabled={processingId === proposal.id}
+                className="flex-1 px-4 py-2 rounded-lg bg-red-500/20 text-red-400 text-sm font-medium hover:bg-red-500/30 disabled:opacity-40 transition-colors"
+              >
+                ✕ Respinge
+              </button>
+            </div>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+interface PhotoEntry {
+  file: File;
+  preview: string;
+  tags: string[];
+  notes: string;
+  aiLoading: boolean;
+  aiDone: boolean;
+  progress: number | null;
+}
+
+const ANCA_LOADER_STYLES = `
+  @keyframes ancaGlow { 0%,100%{opacity:.15} 50%{opacity:1} }
+  @keyframes ancaDot  { 0%,80%,100%{opacity:.2;transform:scale(.8)} 40%{opacity:1;transform:scale(1.2)} }
+  .ul-wrap  { animation: ancaGlow 2.4s ease-in-out infinite; }
+  .ul-dots  { display:flex; justify-content:center; gap:8px; margin-top:20px; }
+  .ul-dots span { width:6px; height:6px; border-radius:50%; background:#fff; animation:ancaDot 1.4s ease-in-out infinite; }
+  .ul-dots span:nth-child(2){animation-delay:.2s}
+  .ul-dots span:nth-child(3){animation-delay:.4s}
+`;
+
+function AllAiLoader({ current, total }: { current: number; total: number }) {
+  return (
+    <div className="absolute inset-0 z-20 bg-black/90 rounded-2xl flex flex-col items-center justify-center gap-6">
+      <style>{ANCA_LOADER_STYLES}</style>
+      <div className="ul-wrap text-center">
+        <div style={{ fontSize: "1.6rem", letterSpacing: "0.25em", textTransform: "uppercase", lineHeight: 1 }}>
+          <span style={{ fontWeight: 700, color: "#fff" }}>Anca</span>
+          <span style={{ fontWeight: 300, color: "#d1d5db" }}>Visuals</span>
+        </div>
+        <div style={{ fontSize: "0.6rem", letterSpacing: "0.35em", textTransform: "uppercase", color: "#9ca3af", fontStyle: "italic", marginTop: 6 }}>
+          You feel it. We frame it.
+        </div>
+      </div>
+      <div className="ul-dots"><span /><span /><span /></div>
+      <div className="text-center">
+        <p className="text-neutral-300 text-sm font-medium">Analizează pozele...</p>
+        <p className="text-neutral-500 text-xs mt-1">Poza {current} din {total}</p>
+      </div>
+    </div>
+  );
+}
+
 function UploadModal({
   onClose,
   onAdded,
@@ -673,94 +928,135 @@ function UploadModal({
   onClose: () => void;
   onAdded: (photo: InspirationPhoto) => void;
 }) {
-  useEffect(() => {
-    document.body.style.overflow = "hidden";
-    return () => { document.body.style.overflow = ""; };
-  }, []);
-
   const inputRef = useRef<HTMLInputElement>(null);
-  const [files, setFiles] = useState<File[]>([]);
-  const [previews, setPreviews] = useState<string[]>([]);
-  const [tags, setTags] = useState<string[]>([]);
+  const touchStartX = useRef<number | null>(null);
+
+  const [pendingFiles, setPendingFiles] = useState<File[]>([]);
+  const [pendingPreviews, setPendingPreviews] = useState<string[]>([]);
+  const [photos, setPhotos] = useState<PhotoEntry[]>([]);
+  const [currentIndex, setCurrentIndex] = useState(0);
   const [customTag, setCustomTag] = useState("");
-  const [notes, setNotes] = useState("");
-  const [progresses, setProgresses] = useState<Record<string, number>>({});
-  const [errors, setErrors] = useState<string[]>([]);
-  const [dragging, setDragging] = useState(false);
   const [uploading, setUploading] = useState(false);
-  const [aiTagLoading, setAiTagLoading] = useState(false);
-  const [aiSuggestedTags, setAiSuggestedTags] = useState<string[] | null>(null);
-  const [aiDebug, setAiDebug] = useState<{ status: number; body: string } | null>(null);
+  const [errors, setErrors] = useState<string[]>([]);
+  const [allAiLoading, setAllAiLoading] = useState(false);
+  const [allAiCurrent, setAllAiCurrent] = useState(0);
 
-  const pickFiles = (newFiles: File[]) => {
-    setFiles((prev) => [...prev, ...newFiles]);
-    setPreviews((prev) => [...prev, ...newFiles.map((f) => URL.createObjectURL(f))]);
+  const hasPhotos = photos.length > 0;
+  const current = photos[currentIndex];
+
+  const hasPending = pendingFiles.length > 0;
+
+  const onPickFiles = (newFiles: File[]) => {
+    const valid = newFiles.filter((f) => f.type.startsWith("image/"));
+    setPendingFiles((prev) => [...prev, ...valid]);
+    setPendingPreviews((prev) => [...prev, ...valid.map((f) => URL.createObjectURL(f))]);
   };
 
-  const removeFile = (index: number) => {
-    setFiles((prev) => prev.filter((_, i) => i !== index));
-    setPreviews((prev) => prev.filter((_, i) => i !== index));
+  const removePending = (index: number) => {
+    setPendingFiles((prev) => prev.filter((_, i) => i !== index));
+    setPendingPreviews((prev) => prev.filter((_, i) => i !== index));
   };
 
-  const toggleTag = (tag: string) =>
-    setTags((prev) => prev.includes(tag) ? prev.filter((t) => t !== tag) : [...prev, tag]);
+  const confirmLoad = () => {
+    if (pendingFiles.length === 0) return;
+    const entries: PhotoEntry[] = pendingFiles.map((file, i) => ({
+      file,
+      preview: pendingPreviews[i],
+      tags: [],
+      notes: "",
+      aiLoading: false,
+      aiDone: false,
+      progress: null,
+    }));
+    setPhotos((prev) => {
+      const updated = [...prev, ...entries];
+      setCurrentIndex(prev.length === 0 ? 0 : prev.length);
+      return updated;
+    });
+    setPendingFiles([]);
+    setPendingPreviews([]);
+  };
+
+  const removePhoto = (index: number) => {
+    setPhotos((prev) => prev.filter((_, i) => i !== index));
+    setCurrentIndex((prev) => Math.min(prev, Math.max(0, photos.length - 2)));
+  };
+
+  const updatePhoto = (index: number, updates: Partial<PhotoEntry>) => {
+    setPhotos((prev) => prev.map((p, i) => i === index ? { ...p, ...updates } : p));
+  };
+
+  const toggleTag = (tag: string) => {
+    if (!current) return;
+    const next = current.tags.includes(tag)
+      ? current.tags.filter((t) => t !== tag)
+      : [...current.tags, tag];
+    updatePhoto(currentIndex, { tags: next });
+  };
 
   const addCustomTag = () => {
+    if (!current) return;
     const newTags = customTag
       .split(/[,;]+/)
       .map((t) => t.trim().toLowerCase())
-      .filter((t) => t.length > 0 && !tags.includes(t));
-    if (newTags.length > 0) setTags((prev) => [...prev, ...newTags]);
+      .filter((t) => t.length > 0 && !current.tags.includes(t));
+    if (newTags.length > 0) updatePhoto(currentIndex, { tags: [...current.tags, ...newTags] });
     setCustomTag("");
   };
 
-  const suggestTagsFromImage = async () => {
-    if (files.length === 0) return;
-    setAiTagLoading(true);
-    setAiDebug(null);
+  const getBase64 = (file: File): Promise<string> =>
+    new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = () => resolve((reader.result as string).split(",")[1]);
+      reader.onerror = reject;
+      reader.readAsDataURL(file);
+    });
+
+  const suggestForIndex = async (index: number): Promise<void> => {
+    const photo = photos[index];
+    if (!photo) return;
+    updatePhoto(index, { aiLoading: true });
     try {
-      const file = files[0];
-      const base64 = await new Promise<string>((resolve, reject) => {
-        const reader = new FileReader();
-        reader.onload = () => {
-          const result = reader.result as string;
-          resolve(result.split(",")[1]);
-        };
-        reader.onerror = reject;
-        reader.readAsDataURL(file);
-      });
-      const mediaType = file.type || "image/jpeg";
+      const base64 = await getBase64(photo.file);
       const res = await fetch("/api/admin/inspiration/suggest-tags-from-image", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ imageBase64: base64, mediaType, availableTags: PRESET_TAGS }),
+        body: JSON.stringify({ imageBase64: base64, mediaType: photo.file.type || "image/jpeg", availableTags: PRESET_TAGS }),
       });
-      const rawText = await res.text();
-      setAiDebug({ status: res.status, body: rawText });
-      let data: { tags?: string[] } = {};
-      try { data = JSON.parse(rawText); } catch { /* not JSON */ }
-      if (data.tags && data.tags.length > 0) {
-        setAiSuggestedTags(data.tags);
-        setTags(data.tags);
-      }
-    } catch (error) {
-      setAiDebug({ status: 0, body: String(error) });
-    } finally {
-      setAiTagLoading(false);
+      const data = await res.json();
+      const newTags: string[] = data.tags ?? [];
+      setPhotos((prev) => prev.map((p, i) => {
+        if (i !== index) return p;
+        const merged = Array.from(new Set([...p.tags, ...newTags]));
+        return { ...p, tags: merged, aiLoading: false, aiDone: true };
+      }));
+    } catch {
+      updatePhoto(index, { aiLoading: false });
     }
   };
 
-  const uploadFile = (file: File): Promise<void> =>
-    new Promise((resolve, reject) => {
-      const safeName = `${Date.now()}_${Math.random().toString(36).slice(2)}_${file.name.replace(/\s+/g, "_")}`;
-      const storageRef = ref(storage, `inspiration-library/${safeName}`);
-      const task = uploadBytesResumable(storageRef, file);
+  const suggestCurrent = () => suggestForIndex(currentIndex);
 
+  const suggestAll = async () => {
+    setAllAiLoading(true);
+    for (let i = 0; i < photos.length; i++) {
+      setAllAiCurrent(i + 1);
+      await suggestForIndex(i);
+    }
+    setAllAiLoading(false);
+    setAllAiCurrent(0);
+  };
+
+  const uploadPhoto = (entry: PhotoEntry, index: number): Promise<void> =>
+    new Promise((resolve, reject) => {
+      const safeName = `${Date.now()}_${Math.random().toString(36).slice(2)}_${entry.file.name.replace(/\s+/g, "_")}`;
+      const storageRef = ref(storage, `inspiration-library/${safeName}`);
+      const task = uploadBytesResumable(storageRef, entry.file);
       task.on(
         "state_changed",
         (snap) => {
           const pct = Math.round((snap.bytesTransferred / snap.totalBytes) * 100);
-          setProgresses((prev) => ({ ...prev, [file.name]: pct }));
+          updatePhoto(index, { progress: pct });
         },
         reject,
         async () => {
@@ -768,198 +1064,325 @@ function UploadModal({
           const res = await fetch("/api/admin/inspiration/photos", {
             method: "POST",
             headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ url, tags, notes }),
+            body: JSON.stringify({ url, tags: entry.tags, notes: entry.notes }),
           });
           const data = await res.json();
-          onAdded({ id: data.id, url, tags, notes, uploadedAt: new Date().toISOString() });
+          onAdded({ id: data.id, url, tags: entry.tags, notes: entry.notes, uploadedAt: new Date().toISOString() });
           resolve();
         },
       );
     });
 
-  const handleSave = async () => {
-    if (files.length === 0) return;
+  const handleSaveAll = async () => {
+    const missingTags = photos.findIndex((p) => p.tags.length === 0);
+    if (missingTags !== -1) {
+      setCurrentIndex(missingTags);
+      setErrors([`Poza ${missingTags + 1} nu are niciun tag. Adaugă cel puțin un tag înainte de salvare.`]);
+      return;
+    }
     setUploading(true);
     setErrors([]);
-    const results = await Promise.allSettled(files.map((f) => uploadFile(f)));
+    const snapshot = [...photos];
+    const results = await Promise.allSettled(snapshot.map((p, i) => uploadPhoto(p, i)));
     const failed = results
-      .map((r, i) => r.status === "rejected" ? files[i].name : null)
+      .map((r, i) => r.status === "rejected" ? snapshot[i].file.name : null)
       .filter(Boolean) as string[];
     setUploading(false);
-    if (failed.length === 0) {
-      onClose();
-    } else {
+    if (failed.length === 0) { onClose(); } else {
       setErrors(failed.map((name) => `Upload eșuat: ${name}`));
     }
   };
 
-  const isUploading = uploading;
-  const totalProgress = files.length === 0 ? 0
-    : Math.round(Object.values(progresses).reduce((a, b) => a + b, 0) / files.length);
+  const handleTouchStart = (e: React.TouchEvent) => { touchStartX.current = e.touches[0].clientX; };
+  const handleTouchEnd = (e: React.TouchEvent) => {
+    if (touchStartX.current === null || allAiLoading) return;
+    const delta = e.changedTouches[0].clientX - touchStartX.current;
+    if (Math.abs(delta) > 50) {
+      if (delta < 0 && currentIndex < photos.length - 1) setCurrentIndex((i) => i + 1);
+      if (delta > 0 && currentIndex > 0) setCurrentIndex((i) => i - 1);
+    }
+    touchStartX.current = null;
+  };
+
+  const photosWithoutTags = photos.filter((p) => p.tags.length === 0).length;
 
   return (
-    <div className="fixed inset-0 bg-black/70 flex items-center justify-center z-50 px-4" onClick={onClose}>
+    <div className="fixed inset-0 bg-black/80 flex items-center justify-center z-50 px-4" onClick={onClose}>
       <div
-        className="bg-neutral-900 border border-neutral-800 rounded-2xl p-6 w-full max-w-md space-y-5 max-h-[90vh] overflow-y-auto"
+        className="relative bg-neutral-900 border border-neutral-800 rounded-2xl w-full max-w-lg max-h-[92vh] overflow-y-auto"
         onClick={(e) => e.stopPropagation()}
       >
-        <div className="flex items-center justify-between">
+        {/* AncaVisuals loader overlay during suggestAll */}
+        {allAiLoading && <AllAiLoader current={allAiCurrent} total={photos.length} />}
+
+        {/* Header */}
+        <div className="flex items-center justify-between px-5 py-4 border-b border-neutral-800 sticky top-0 bg-neutral-900 z-10">
           <h2 className="text-white text-base font-semibold">
-            Adaugă {files.length > 1 ? `${files.length} poze` : "poze"}
+            {hasPhotos ? `${photos.length} ${photos.length === 1 ? "poză" : "poze"} · poza ${currentIndex + 1}` : "Adaugă poze"}
           </h2>
           <button onClick={onClose} className="text-neutral-500 hover:text-white transition-colors text-lg">✕</button>
         </div>
 
-        {/* Drop zone */}
-        <div
-          onDragOver={(e) => { e.preventDefault(); setDragging(true); }}
-          onDragLeave={() => setDragging(false)}
-          onDrop={(e) => { e.preventDefault(); setDragging(false); pickFiles(Array.from(e.dataTransfer.files)); }}
-          onClick={() => inputRef.current?.click()}
-          className={`border-2 border-dashed rounded-xl p-6 text-center cursor-pointer transition-colors ${
-            dragging ? "border-violet-500 bg-violet-500/10" : "border-neutral-700 hover:border-neutral-500"
-          }`}
-        >
-          <p className="text-neutral-400 text-sm">Trage poze sau <span className="underline text-neutral-200">selectează</span></p>
-          <p className="text-neutral-600 text-xs mt-1">JPG, PNG, WEBP · multiple fișiere acceptate</p>
-          <input
-            ref={inputRef}
-            type="file"
-            accept=".jpg,.jpeg,.png,.webp"
-            multiple
-            className="hidden"
-            onChange={(e) => { if (e.target.files) pickFiles(Array.from(e.target.files)); }}
-          />
-        </div>
+        <div className="p-5 space-y-5">
 
-        {/* Previews grid */}
-        {files.length > 0 && (
-          <div className="grid grid-cols-3 gap-2">
-            {files.map((file, i) => (
-              <div key={i} className="relative rounded-lg overflow-hidden aspect-square group">
-                <img src={previews[i]} alt="" className="w-full h-full object-cover" />
-                {isUploading ? (
-                  <div className="absolute inset-0 bg-black/50 flex items-center justify-center">
-                    <span className="text-white text-xs font-semibold">{progresses[file.name] ?? 0}%</span>
+          {/* File picker section */}
+          <div className="space-y-3">
+            <div className="flex items-center gap-3">
+              <button
+                onClick={() => inputRef.current?.click()}
+                className="flex items-center gap-2 px-4 py-2 rounded-xl border border-neutral-700 text-neutral-300 text-sm hover:border-violet-500 hover:text-violet-300 transition-colors"
+              >
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+                  <polyline points="17 8 12 3 7 8" />
+                  <line x1="12" y1="3" x2="12" y2="15" />
+                </svg>
+                Selectează poze
+              </button>
+              <input
+                ref={inputRef}
+                type="file"
+                accept=".jpg,.jpeg,.png,.webp"
+                multiple
+                className="hidden"
+                onChange={(e) => { if (e.target.files) onPickFiles(Array.from(e.target.files)); }}
+              />
+              {hasPending && (
+                <button
+                  onClick={confirmLoad}
+                  className="flex items-center gap-2 px-4 py-2 rounded-xl bg-violet-600 text-white text-sm font-medium hover:bg-violet-500 transition-colors"
+                >
+                  Încarcă ({pendingFiles.length})
+                </button>
+              )}
+            </div>
+
+            {/* Pending previews */}
+            {hasPending && (
+              <div className="flex gap-2 overflow-x-auto pb-1">
+                {pendingFiles.map((_, i) => (
+                  <div key={i} className="relative shrink-0 w-16 h-16 rounded-lg overflow-hidden group">
+                    <img src={pendingPreviews[i]} alt="" className="w-full h-full object-cover" />
+                    <button
+                      onClick={() => removePending(i)}
+                      className="absolute top-0.5 right-0.5 w-5 h-5 rounded-full bg-black/70 text-white text-xs flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity"
+                    >
+                      ✕
+                    </button>
                   </div>
-                ) : (
+                ))}
+              </div>
+            )}
+          </div>
+
+          {hasPhotos && (
+            <>
+              {/* Featured photo */}
+              <div
+                className="relative rounded-xl overflow-hidden bg-neutral-950"
+                style={{ aspectRatio: "4/3" }}
+                onTouchStart={handleTouchStart}
+                onTouchEnd={handleTouchEnd}
+              >
+                <img src={current.preview} alt="" className="w-full h-full object-contain" />
+
+                {/* Per-photo AI loading */}
+                {current.aiLoading && !allAiLoading && (
+                  <div className="absolute inset-0 bg-black/70 flex items-center justify-center">
+                    <div className="flex flex-col items-center gap-3">
+                      <div className="w-8 h-8 border-2 border-violet-400 border-t-transparent rounded-full animate-spin" />
+                      <p className="text-neutral-300 text-xs">Analizează poza...</p>
+                    </div>
+                  </div>
+                )}
+
+                {/* Upload progress */}
+                {current.progress !== null && (
+                  <div className="absolute inset-0 bg-black/70 flex flex-col items-center justify-center gap-3">
+                    <p className="text-white font-semibold text-lg">{current.progress}%</p>
+                    <div className="w-36 bg-neutral-700 rounded-full h-1.5">
+                      <div className="bg-violet-500 h-1.5 rounded-full transition-all" style={{ width: `${current.progress}%` }} />
+                    </div>
+                  </div>
+                )}
+
+                {/* AI done badge */}
+                {current.aiDone && !current.aiLoading && (
+                  <div className="absolute top-2 left-2 px-2 py-0.5 rounded-full bg-emerald-500/20 border border-emerald-500/40 text-emerald-400 text-xs">
+                    ✦ AI gata
+                  </div>
+                )}
+
+                {/* Nav arrows */}
+                {currentIndex > 0 && (
                   <button
-                    onClick={() => removeFile(i)}
-                    className="absolute top-1 right-1 w-5 h-5 rounded-full bg-black/70 text-white text-xs flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity"
+                    onClick={() => !allAiLoading && setCurrentIndex((i) => i - 1)}
+                    className="absolute left-2 top-1/2 -translate-y-1/2 w-9 h-9 rounded-full bg-black/60 text-white text-xl flex items-center justify-center hover:bg-black/80 transition-colors"
+                  >
+                    ‹
+                  </button>
+                )}
+                {currentIndex < photos.length - 1 && (
+                  <button
+                    onClick={() => !allAiLoading && setCurrentIndex((i) => i + 1)}
+                    className="absolute right-2 top-1/2 -translate-y-1/2 w-9 h-9 rounded-full bg-black/60 text-white text-xl flex items-center justify-center hover:bg-black/80 transition-colors"
+                  >
+                    ›
+                  </button>
+                )}
+
+                {/* Delete */}
+                {!uploading && !allAiLoading && (
+                  <button
+                    onClick={() => removePhoto(currentIndex)}
+                    className="absolute top-2 right-2 w-7 h-7 rounded-full bg-red-500/80 text-white text-xs flex items-center justify-center hover:bg-red-500 transition-colors"
+                    title="Șterge poza"
                   >
                     ✕
                   </button>
                 )}
+
+                {/* Counter */}
+                <div className="absolute bottom-2 left-1/2 -translate-x-1/2 px-2.5 py-0.5 rounded-full bg-black/60 text-white text-xs">
+                  {currentIndex + 1} / {photos.length}
+                </div>
               </div>
-            ))}
-          </div>
-        )}
 
-        {/* Tag selector */}
-        <div>
-          <div className="flex items-center justify-between mb-3">
-            <p className="text-neutral-400 text-xs uppercase tracking-wide font-medium">Tag-uri</p>
-            {files.length > 0 && (
-              <button
-                onClick={suggestTagsFromImage}
-                disabled={aiTagLoading}
-                className="flex items-center gap-1.5 px-3 py-1 rounded-lg bg-violet-500/20 text-violet-300 text-xs hover:bg-violet-500/30 disabled:opacity-50 transition-colors"
-              >
-                {aiTagLoading ? (
-                  <span className="w-3 h-3 border-2 border-violet-400 border-t-transparent rounded-full animate-spin inline-block" />
-                ) : (
-                  <span>✦</span>
-                )}
-                {aiTagLoading ? "Analizează..." : "Sugerează cu AI"}
-              </button>
-            )}
-          </div>
+              {/* Thumbnails */}
+              {photos.length > 1 && (
+                <div className="flex gap-2 overflow-x-auto pb-1">
+                  {photos.map((photo, i) => (
+                    <button
+                      key={i}
+                      onClick={() => !allAiLoading && setCurrentIndex(i)}
+                      className={`relative shrink-0 w-14 h-14 rounded-lg overflow-hidden border-2 transition-all ${
+                        i === currentIndex ? "border-violet-500" : "border-transparent opacity-50 hover:opacity-90"
+                      }`}
+                    >
+                      <img src={photo.preview} alt="" className="w-full h-full object-cover" />
+                      {photo.tags.length === 0 && (
+                        <div className="absolute inset-0 flex items-center justify-center bg-black/40">
+                          <span className="text-amber-400 text-xs">!</span>
+                        </div>
+                      )}
+                      {photo.aiDone && photo.tags.length > 0 && (
+                        <div className="absolute bottom-0.5 right-0.5 w-3.5 h-3.5 rounded-full bg-emerald-500 flex items-center justify-center">
+                          <span style={{ fontSize: "8px", color: "#fff" }}>✓</span>
+                        </div>
+                      )}
+                      {photo.aiLoading && (
+                        <div className="absolute inset-0 bg-black/50 flex items-center justify-center">
+                          <div className="w-4 h-4 border-2 border-violet-400 border-t-transparent rounded-full animate-spin" />
+                        </div>
+                      )}
+                    </button>
+                  ))}
+                </div>
+              )}
 
-          {aiDebug !== null && (
-            <div className="mt-2 p-3 rounded-lg bg-neutral-950 border border-neutral-700 space-y-1">
-              <div className="flex items-center justify-between">
-                <p className="text-xs font-mono text-neutral-400">
-                  DEBUG AI · HTTP {aiDebug.status === 0 ? "network error" : aiDebug.status}
+              {/* AI buttons */}
+              <div className="flex gap-2">
+                <button
+                  onClick={suggestCurrent}
+                  disabled={current.aiLoading || allAiLoading || uploading}
+                  className="flex-1 flex items-center justify-center gap-1.5 px-3 py-2.5 rounded-xl bg-violet-500/15 border border-violet-500/30 text-violet-300 text-xs font-medium hover:bg-violet-500/25 disabled:opacity-40 transition-colors"
+                >
+                  {current.aiLoading ? (
+                    <span className="w-3 h-3 border-2 border-violet-400 border-t-transparent rounded-full animate-spin" />
+                  ) : <span>✦</span>}
+                  Sugerează AI
+                </button>
+                <button
+                  onClick={suggestAll}
+                  disabled={allAiLoading || uploading}
+                  className="flex-1 flex items-center justify-center gap-1.5 px-3 py-2.5 rounded-xl bg-violet-500/15 border border-violet-500/30 text-violet-300 text-xs font-medium hover:bg-violet-500/25 disabled:opacity-40 transition-colors"
+                >
+                  <span>✦✦</span>
+                  Sugerează AI (All)
+                </button>
+              </div>
+
+              {/* Tags for current photo */}
+              <div>
+                <div className="flex items-center justify-between mb-2">
+                  <p className="text-neutral-400 text-xs uppercase tracking-wide font-medium">
+                    Tag-uri
+                    {current.tags.length > 0
+                      ? <span className="ml-1.5 text-violet-400 normal-case font-normal">· {current.tags.length} selectate</span>
+                      : <span className="ml-1.5 text-amber-400 normal-case font-normal">· niciun tag</span>
+                    }
+                  </p>
+                  {current.tags.length > 0 && (
+                    <button
+                      onClick={() => updatePhoto(currentIndex, { tags: [], aiDone: false })}
+                      className="text-xs text-neutral-600 hover:text-neutral-400 underline underline-offset-2 transition-colors"
+                    >
+                      Resetează
+                    </button>
+                  )}
+                </div>
+                <div className="flex flex-wrap gap-1.5 max-h-32 overflow-y-auto">
+                  {PRESET_TAGS.map((tag) => (
+                    <TagPill key={tag} tag={tag} selected={current.tags.includes(tag)} onClick={() => toggleTag(tag)} />
+                  ))}
+                </div>
+                <div className="flex gap-2 mt-2">
+                  <input
+                    className="flex-1 bg-neutral-800 text-white text-sm border border-neutral-700 rounded-lg px-3 py-1.5 outline-none focus:border-violet-500 transition-colors placeholder-neutral-600"
+                    placeholder="Tag custom separat prin virgulă..."
+                    value={customTag}
+                    onChange={(e) => setCustomTag(e.target.value)}
+                    onKeyDown={(e) => { if (e.key === "Enter") { e.preventDefault(); addCustomTag(); } }}
+                  />
+                  <button
+                    onClick={addCustomTag}
+                    className="px-3 py-1.5 rounded-lg bg-neutral-800 text-neutral-300 text-xs hover:bg-neutral-700 transition-colors"
+                  >
+                    Adaugă
+                  </button>
+                </div>
+              </div>
+
+              {/* Notes per photo */}
+              <div>
+                <p className="text-neutral-400 text-xs uppercase tracking-wide font-medium mb-1">
+                  Notă · poza {currentIndex + 1} <span className="normal-case font-normal text-neutral-600">(opțional)</span>
                 </p>
-                <button onClick={() => setAiDebug(null)} className="text-neutral-600 hover:text-neutral-300 text-xs">✕</button>
+                <textarea
+                  className="w-full bg-neutral-800 text-white text-sm border border-neutral-700 rounded-lg px-3 py-2 outline-none focus:border-neutral-500 transition-colors resize-none placeholder-neutral-600"
+                  rows={2}
+                  placeholder="ex: unghi special, lumină naturală..."
+                  value={current.notes}
+                  onChange={(e) => updatePhoto(currentIndex, { notes: e.target.value })}
+                />
               </div>
-              <pre className="text-xs text-neutral-300 whitespace-pre-wrap break-all max-h-40 overflow-y-auto">
-                {aiDebug.body}
-              </pre>
-            </div>
+            </>
           )}
 
-          {aiSuggestedTags !== null && (
-            <div className="space-y-2 mb-2">
-              <p className="text-neutral-600 text-xs">Bifează tag-urile corecte:</p>
-              <div className="flex flex-wrap gap-1.5">
-                {aiSuggestedTags.map((tag) => (
-                  <TagPill key={tag} tag={tag} selected={tags.includes(tag)} onClick={() => toggleTag(tag)} />
-                ))}
-              </div>
-              <button
-                onClick={() => { setAiSuggestedTags(null); setTags([]); }}
-                className="text-xs text-neutral-600 hover:text-neutral-400 underline underline-offset-2 transition-colors"
-              >
-                Resetează
-              </button>
-            </div>
-          )}
+          {errors.map((err, i) => (
+            <p key={i} className="text-red-400 text-xs bg-red-400/10 border border-red-400/20 rounded-lg px-3 py-2">{err}</p>
+          ))}
 
-          <div className="flex gap-2 mt-2">
-            <input
-              className="flex-1 bg-neutral-800 text-white text-sm border border-neutral-700 rounded-lg px-3 py-1.5 outline-none focus:border-violet-500 transition-colors placeholder-neutral-600"
-              placeholder="Adaugă tag-uri separate prin virgulă..."
-              value={customTag}
-              onChange={(e) => setCustomTag(e.target.value)}
-              onKeyDown={(e) => { if (e.key === "Enter") { e.preventDefault(); addCustomTag(); } }}
-            />
+          <div className="flex gap-3">
             <button
-              onClick={addCustomTag}
-              className="px-3 py-1.5 rounded-lg bg-neutral-800 text-neutral-300 text-xs hover:bg-neutral-700 transition-colors"
+              onClick={onClose}
+              className="flex-1 px-4 py-2.5 rounded-xl border border-neutral-700 text-neutral-300 text-sm hover:border-neutral-500 transition-colors"
             >
-              Adaugă
+              Anulează
+            </button>
+            <button
+              onClick={handleSaveAll}
+              disabled={photos.length === 0 || uploading || allAiLoading}
+              className="flex-1 px-4 py-2.5 rounded-xl bg-violet-600 text-white text-sm font-semibold hover:bg-violet-500 disabled:opacity-40 transition-colors"
+            >
+              {uploading
+                ? "Se încarcă..."
+                : photosWithoutTags > 0
+                  ? `${photosWithoutTags} poze fără tag-uri`
+                  : `Salvează pe toate (${photos.length})`
+              }
             </button>
           </div>
-        </div>
-
-        {/* Notes */}
-        <div>
-          <p className="text-neutral-400 text-xs uppercase tracking-wide font-medium mb-1">Notă (opțional)</p>
-          <textarea
-            className="w-full bg-neutral-800 text-white text-sm border border-neutral-700 rounded-lg px-3 py-2 outline-none focus:border-neutral-500 transition-colors resize-none placeholder-neutral-600"
-            rows={2}
-            placeholder="ex: unghi special, lumină naturală..."
-            value={notes}
-            onChange={(e) => setNotes(e.target.value)}
-          />
-        </div>
-
-        {/* Overall progress */}
-        {isUploading && (
-          <div className="space-y-1">
-            <p className="text-xs text-neutral-400">Se încarcă... {totalProgress}%</p>
-            <div className="w-full bg-neutral-700 rounded-full h-1">
-              <div className="bg-violet-500 h-1 rounded-full transition-all" style={{ width: `${totalProgress}%` }} />
-            </div>
-          </div>
-        )}
-
-        {errors.map((err, i) => (
-          <p key={i} className="text-red-400 text-xs bg-red-400/10 border border-red-400/20 rounded-lg px-3 py-2">{err}</p>
-        ))}
-
-        <div className="flex gap-3">
-          <button onClick={onClose} className="flex-1 px-4 py-2.5 rounded-xl border border-neutral-700 text-neutral-300 text-sm hover:border-neutral-500 transition-colors">
-            Anulează
-          </button>
-          <button
-            onClick={handleSave}
-            disabled={files.length === 0 || isUploading || tags.length === 0}
-            className="flex-1 px-4 py-2.5 rounded-xl bg-violet-600 text-white text-sm font-semibold hover:bg-violet-500 disabled:opacity-40 transition-colors"
-          >
-            {isUploading ? `Se încarcă... ${totalProgress}%` : `Salvează${files.length > 1 ? ` (${files.length})` : ""}`}
-          </button>
         </div>
       </div>
     </div>

--- a/src/client/features/admin/components/MementosPage.tsx
+++ b/src/client/features/admin/components/MementosPage.tsx
@@ -1,5 +1,6 @@
 import React, { useReducer, useEffect, useState, useMemo } from "react";
 import { useNavigate } from "react-router-dom";
+import { useBodyScrollLock } from "../../../hooks/useBodyScrollLock";
 import AncaLoader from "../../../components/UI/AncaLoader";
 
 interface Memento {
@@ -121,6 +122,7 @@ export default function MementosPage() {
   const [showAdd, setShowAdd] = useState(false);
   const [testStatus, setTestStatus] = useState<"idle" | "loading" | "ok" | "err">("idle");
   const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
+  useBodyScrollLock(showAdd || confirmDeleteId !== null);
 
   const now = useMemo(() => new Date(), []);
 
@@ -415,6 +417,7 @@ function AddMementoModal({ onClose, onAdded }: {
   onClose: () => void;
   onAdded: (m: Memento) => void;
 }) {
+  useBodyScrollLock(true);
   const [form, setForm] = useState<AddForm>(createDefaultAddForm);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState("");

--- a/src/client/features/admin/components/Moderation/ModeratorAlbumsPage.tsx
+++ b/src/client/features/admin/components/Moderation/ModeratorAlbumsPage.tsx
@@ -54,6 +54,18 @@ export default function ModeratorAlbumsPage() {
           Selectează un album, alege pozele care nu sunt bune pentru client și trimite spre moderare.
         </p>
 
+        <button
+          onClick={() => navigate("/colaborator")}
+          className="flex items-center gap-2 px-4 py-2.5 rounded-xl bg-violet-500/15 border border-violet-500/30 text-violet-300 text-sm hover:bg-violet-500/25 transition-colors w-full"
+        >
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <rect x="3" y="3" width="18" height="18" rx="2" />
+            <circle cx="8.5" cy="8.5" r="1.5" />
+            <polyline points="21 15 16 10 5 21" />
+          </svg>
+          Propune poze pentru galeria de inspirație
+        </button>
+
         {loading && (
           <p className="text-neutral-600 text-sm">Se încarcă albumele...</p>
         )}

--- a/src/client/features/collaborator/CollaboratorPage.tsx
+++ b/src/client/features/collaborator/CollaboratorPage.tsx
@@ -1,0 +1,762 @@
+import React, { useEffect, useReducer, useRef, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { ref as storageRef, uploadBytesResumable, getDownloadURL } from "firebase/storage";
+import { storage } from "../../firebase";
+import useAuth from "../admin/auth/useAuth";
+import AncaLoader from "../../components/UI/AncaLoader";
+
+const PRESET_TAGS = [
+  "nuntă", "botez", "cununia civilă", "logodnă", "cununie",
+  "biserică", "altar", "restaurant", "sală", "curte", "grădină", "parc",
+  "exterior", "interior", "natură", "terrasă", "mansardă", "plajă",
+  "mire", "mireasă", "mire+mireasă", "nași", "nașă", "nas",
+  "socri", "părinți", "bunici", "tineri-căsătoriți",
+  "bebeluș", "nași-botez", "cristelniță",
+  "grup", "copii", "portret", "familie", "invitați",
+  "ceremonie", "primul-dans", "vals", "hora", "primul-sărut",
+  "schimb-inele", "tort", "buchet-aruncat", "discurs", "felicitări",
+  "intrare", "ieșire", "petrecere", "jocul-mirilor",
+  "fum-artificial", "confetti", "foc-artificii", "aplauze",
+  "lumânare", "botezul-propriu-zis", "masa-botez",
+  "sesiune-foto", "after-session",
+  "detalii", "buchet", "verighete", "rochie", "voal", "costum",
+  "pantofi", "aranjament-floral", "invitație", "tort-nuntă", "tort-botez",
+  "lumânare-nuntă", "coronița", "candy-bar", "decorațiuni", "flori", "baloane",
+  "emoție", "lacrimi", "zâmbet", "râs", "romantic", "vesel", "intim",
+  "golden-hour", "lumină-naturală", "lumina-ferestrei", "backlight",
+  "seară", "lumini", "dramatic", "moody",
+  "candid", "editorial", "fine-art", "alb-negru", "silhouetă",
+  "close-up", "wide-angle", "reflecție",
+  "decor", "machiaj", "dans",
+];
+
+interface InspirationPhoto {
+  id: string;
+  url: string;
+  tags: string[];
+  notes?: string;
+}
+
+interface Proposal {
+  id: string;
+  url: string;
+  tags: string[];
+  notes: string;
+  status: "pending" | "approved" | "rejected";
+  rejectionReason: string;
+  proposedAt: string;
+}
+
+interface PhotoDraft {
+  file: File;
+  preview: string;
+  tags: string[];
+  notes: string;
+  aiLoading: boolean;
+  progress: number | null;
+}
+
+type Tab = "gallery" | "propose";
+
+interface State {
+  tab: Tab;
+  galleryPhotos: InspirationPhoto[];
+  galleryLoading: boolean;
+  proposals: Proposal[];
+  proposalsLoading: boolean;
+  drafts: PhotoDraft[];
+  draftIndex: number;
+  customTag: string;
+  submitting: boolean;
+  submitError: string;
+  submitSuccess: boolean;
+}
+
+type Action =
+  | { type: "SET_TAB"; tab: Tab }
+  | { type: "SET_GALLERY"; photos: InspirationPhoto[] }
+  | { type: "SET_GALLERY_LOADING"; loading: boolean }
+  | { type: "SET_PROPOSALS"; proposals: Proposal[] }
+  | { type: "SET_PROPOSALS_LOADING"; loading: boolean }
+  | { type: "ADD_DRAFTS"; drafts: PhotoDraft[] }
+  | { type: "REMOVE_DRAFT"; index: number }
+  | { type: "SET_DRAFT_INDEX"; index: number }
+  | { type: "UPDATE_DRAFT"; index: number; updates: Partial<PhotoDraft> }
+  | { type: "SET_CUSTOM_TAG"; value: string }
+  | { type: "SET_SUBMITTING"; value: boolean }
+  | { type: "SET_SUBMIT_ERROR"; error: string }
+  | { type: "SET_SUBMIT_SUCCESS"; value: boolean }
+  | { type: "CLEAR_DRAFTS" };
+
+function reducer(state: State, action: Action): State {
+  switch (action.type) {
+    case "SET_TAB":
+      return { ...state, tab: action.tab, submitSuccess: false, submitError: "" };
+    case "SET_GALLERY":
+      return { ...state, galleryPhotos: action.photos };
+    case "SET_GALLERY_LOADING":
+      return { ...state, galleryLoading: action.loading };
+    case "SET_PROPOSALS":
+      return { ...state, proposals: action.proposals };
+    case "SET_PROPOSALS_LOADING":
+      return { ...state, proposalsLoading: action.loading };
+    case "ADD_DRAFTS": {
+      const total = state.drafts.length + action.drafts.length;
+      const allowed = action.drafts.slice(0, 6 - state.drafts.length);
+      const newDrafts = [...state.drafts, ...allowed];
+      return {
+        ...state,
+        drafts: newDrafts,
+        draftIndex: state.drafts.length === 0 ? 0 : state.draftIndex,
+        submitError: total > 6 ? "Poți propune maxim 6 poze deodată." : "",
+      };
+    }
+    case "REMOVE_DRAFT": {
+      const next = state.drafts.filter((_, i) => i !== action.index);
+      return {
+        ...state,
+        drafts: next,
+        draftIndex: Math.min(state.draftIndex, Math.max(0, next.length - 1)),
+      };
+    }
+    case "SET_DRAFT_INDEX":
+      return { ...state, draftIndex: action.index };
+    case "UPDATE_DRAFT":
+      return {
+        ...state,
+        drafts: state.drafts.map((draft, i) =>
+          i === action.index ? { ...draft, ...action.updates } : draft
+        ),
+      };
+    case "SET_CUSTOM_TAG":
+      return { ...state, customTag: action.value };
+    case "SET_SUBMITTING":
+      return { ...state, submitting: action.value };
+    case "SET_SUBMIT_ERROR":
+      return { ...state, submitError: action.error };
+    case "SET_SUBMIT_SUCCESS":
+      return { ...state, submitSuccess: action.value };
+    case "CLEAR_DRAFTS":
+      return { ...state, drafts: [], draftIndex: 0, customTag: "", submitSuccess: true };
+    default:
+      return state;
+  }
+}
+
+const initialState: State = {
+  tab: "propose",
+  galleryPhotos: [],
+  galleryLoading: false,
+  proposals: [],
+  proposalsLoading: false,
+  drafts: [],
+  draftIndex: 0,
+  customTag: "",
+  submitting: false,
+  submitError: "",
+  submitSuccess: false,
+};
+
+function TagPill({ tag, selected, onClick }: { tag: string; selected: boolean; onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`px-3 py-1 rounded-full text-xs font-medium transition-colors whitespace-nowrap ${
+        selected
+          ? "bg-violet-500 text-white"
+          : "bg-neutral-800 text-neutral-400 hover:bg-neutral-700 hover:text-white"
+      }`}
+    >
+      {tag}
+    </button>
+  );
+}
+
+function StatusBadge({ status }: { status: Proposal["status"] }) {
+  if (status === "pending") {
+    return (
+      <span className="px-2 py-0.5 rounded-full bg-amber-500/20 text-amber-400 text-xs font-medium">
+        În așteptare
+      </span>
+    );
+  }
+  if (status === "approved") {
+    return (
+      <span className="px-2 py-0.5 rounded-full bg-emerald-500/20 text-emerald-400 text-xs font-medium">
+        ✓ Acceptat
+      </span>
+    );
+  }
+  return (
+    <span className="px-2 py-0.5 rounded-full bg-red-500/20 text-red-400 text-xs font-medium">
+      Respins
+    </span>
+  );
+}
+
+export default function CollaboratorPage() {
+  const { auth, logOut } = useAuth();
+  const navigate = useNavigate();
+  const [state, dispatch] = useReducer(reducer, initialState);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const touchStartX = useRef<number | null>(null);
+
+  const currentDraft = state.drafts[state.draftIndex] ?? null;
+
+  useEffect(() => {
+    if (!auth.accessToken) return;
+    dispatch({ type: "SET_PROPOSALS_LOADING", loading: true });
+    fetch("/api/inspiration-proposals/my", {
+      headers: { Authorization: `Bearer ${auth.accessToken}` },
+    })
+      .then((response) => response.json())
+      .then((data: { proposals?: Proposal[] }) => {
+        dispatch({ type: "SET_PROPOSALS", proposals: data.proposals ?? [] });
+      })
+      .finally(() => dispatch({ type: "SET_PROPOSALS_LOADING", loading: false }));
+  }, [auth.accessToken]);
+
+  useEffect(() => {
+    if (state.tab !== "gallery") return;
+    if (state.galleryPhotos.length > 0) return;
+    dispatch({ type: "SET_GALLERY_LOADING", loading: true });
+    fetch("/api/admin/inspiration/photos")
+      .then((response) => response.json())
+      .then((data: { photos?: InspirationPhoto[] }) => {
+        dispatch({ type: "SET_GALLERY", photos: data.photos ?? [] });
+      })
+      .finally(() => dispatch({ type: "SET_GALLERY_LOADING", loading: false }));
+  }, [state.tab, state.galleryPhotos.length]);
+
+  const handlePickFiles = (files: FileList | null) => {
+    if (!files) return;
+    const imageFiles = Array.from(files).filter((file) => file.type.startsWith("image/"));
+    const newDrafts: PhotoDraft[] = imageFiles.slice(0, 6 - state.drafts.length).map((file) => ({
+      file,
+      preview: URL.createObjectURL(file),
+      tags: [],
+      notes: "",
+      aiLoading: false,
+      progress: null,
+    }));
+    dispatch({ type: "ADD_DRAFTS", drafts: newDrafts });
+    if (inputRef.current) inputRef.current.value = "";
+  };
+
+  const getBase64 = (file: File): Promise<string> =>
+    new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = () => resolve((reader.result as string).split(",")[1]);
+      reader.onerror = reject;
+      reader.readAsDataURL(file);
+    });
+
+  const suggestAI = async (index: number) => {
+    const draft = state.drafts[index];
+    if (!draft) return;
+    dispatch({ type: "UPDATE_DRAFT", index, updates: { aiLoading: true } });
+    try {
+      const base64 = await getBase64(draft.file);
+      const response = await fetch("/api/admin/inspiration/suggest-tags-from-image", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          imageBase64: base64,
+          mediaType: draft.file.type || "image/jpeg",
+          availableTags: PRESET_TAGS,
+        }),
+      });
+      const data = await response.json();
+      const newTags: string[] = data.tags ?? [];
+      dispatch({
+        type: "UPDATE_DRAFT",
+        index,
+        updates: {
+          tags: Array.from(new Set([...draft.tags, ...newTags])),
+          aiLoading: false,
+        },
+      });
+    } catch {
+      dispatch({ type: "UPDATE_DRAFT", index, updates: { aiLoading: false } });
+    }
+  };
+
+  const toggleTag = (tag: string) => {
+    if (!currentDraft) return;
+    const updated = currentDraft.tags.includes(tag)
+      ? currentDraft.tags.filter((tagItem) => tagItem !== tag)
+      : [...currentDraft.tags, tag];
+    dispatch({ type: "UPDATE_DRAFT", index: state.draftIndex, updates: { tags: updated } });
+  };
+
+  const addCustomTag = () => {
+    if (!currentDraft) return;
+    const newTags = state.customTag
+      .split(/[,;]+/)
+      .map((tagItem) => tagItem.trim().toLowerCase())
+      .filter((tagItem) => tagItem.length > 0 && !currentDraft.tags.includes(tagItem));
+    if (newTags.length > 0) {
+      dispatch({
+        type: "UPDATE_DRAFT",
+        index: state.draftIndex,
+        updates: { tags: [...currentDraft.tags, ...newTags] },
+      });
+    }
+    dispatch({ type: "SET_CUSTOM_TAG", value: "" });
+  };
+
+  const uploadDraft = (draft: PhotoDraft, index: number): Promise<string> =>
+    new Promise((resolve, reject) => {
+      const uid = auth.user?.uid ?? "unknown";
+      const safeName = `${Date.now()}_${Math.random().toString(36).slice(2)}_${draft.file.name.replace(/\s+/g, "_")}`;
+      const fileRef = storageRef(storage, `inspiration-proposals/${uid}/${safeName}`);
+      const task = uploadBytesResumable(fileRef, draft.file);
+      task.on(
+        "state_changed",
+        (snap) => {
+          const percent = Math.round((snap.bytesTransferred / snap.totalBytes) * 100);
+          dispatch({ type: "UPDATE_DRAFT", index, updates: { progress: percent } });
+        },
+        reject,
+        async () => {
+          const downloadUrl = await getDownloadURL(task.snapshot.ref);
+          resolve(downloadUrl);
+        },
+      );
+    });
+
+  const handleSubmit = async () => {
+    if (state.drafts.length === 0) return;
+    dispatch({ type: "SET_SUBMIT_ERROR", error: "" });
+    dispatch({ type: "SET_SUBMITTING", value: true });
+
+    try {
+      const uploadedUrls = await Promise.all(
+        state.drafts.map((draft, index) => uploadDraft(draft, index))
+      );
+
+      const photos = state.drafts.map((draft, index) => ({
+        url: uploadedUrls[index],
+        tags: draft.tags,
+        notes: draft.notes,
+      }));
+
+      const response = await fetch("/api/inspiration-proposals/propose", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${auth.accessToken}`,
+        },
+        body: JSON.stringify({ photos }),
+      });
+
+      const data = await response.json();
+      if (!response.ok) {
+        dispatch({ type: "SET_SUBMIT_ERROR", error: data.error ?? "Eroare la trimitere." });
+        return;
+      }
+
+      dispatch({ type: "CLEAR_DRAFTS" });
+
+      const proposalsResponse = await fetch("/api/inspiration-proposals/my", {
+        headers: { Authorization: `Bearer ${auth.accessToken}` },
+      });
+      const proposalsData = await proposalsResponse.json();
+      dispatch({ type: "SET_PROPOSALS", proposals: proposalsData.proposals ?? [] });
+    } catch (error) {
+      dispatch({ type: "SET_SUBMIT_ERROR", error: String(error) });
+    } finally {
+      dispatch({ type: "SET_SUBMITTING", value: false });
+    }
+  };
+
+  const handleLogout = async () => {
+    await logOut();
+    navigate("/login", { replace: true });
+  };
+
+  const handleTouchStart = (event: React.TouchEvent) => {
+    touchStartX.current = event.touches[0].clientX;
+  };
+
+  const handleTouchEnd = (event: React.TouchEvent) => {
+    if (touchStartX.current === null) return;
+    const delta = event.changedTouches[0].clientX - touchStartX.current;
+    if (Math.abs(delta) > 50) {
+      if (delta < 0 && state.draftIndex < state.drafts.length - 1) {
+        dispatch({ type: "SET_DRAFT_INDEX", index: state.draftIndex + 1 });
+      } else if (delta > 0 && state.draftIndex > 0) {
+        dispatch({ type: "SET_DRAFT_INDEX", index: state.draftIndex - 1 });
+      }
+    }
+    touchStartX.current = null;
+  };
+
+  const pendingCount = state.proposals.filter((proposal) => proposal.status === "pending").length;
+
+  return (
+    <div className="min-h-screen bg-neutral-950 px-4 py-8">
+      <div className="max-w-xl mx-auto space-y-6">
+
+        {/* Header */}
+        <div className="flex items-start justify-between">
+          <div>
+            <h1 className="text-white text-xl font-light tracking-tight">
+              <span style={{ fontWeight: 700 }}>Anca</span>
+              <span style={{ fontWeight: 300, color: "#d1d5db" }}>Visuals</span>
+            </h1>
+            <p className="text-neutral-500 text-xs mt-0.5">{auth.user?.email}</p>
+          </div>
+          <button
+            onClick={handleLogout}
+            className="flex items-center gap-2 px-3 py-1.5 rounded-lg border border-neutral-800 text-neutral-400 text-xs hover:border-red-500/50 hover:text-red-400 transition-colors"
+          >
+            <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
+              <polyline points="16 17 21 12 16 7" />
+              <line x1="21" y1="12" x2="9" y2="12" />
+            </svg>
+            Deconectare
+          </button>
+        </div>
+
+        {/* Tabs */}
+        <div className="flex gap-1 bg-neutral-900 border border-neutral-800 rounded-xl p-1">
+          <button
+            onClick={() => dispatch({ type: "SET_TAB", tab: "propose" })}
+            className={`flex-1 py-2 px-3 rounded-lg text-sm font-medium transition-colors ${
+              state.tab === "propose"
+                ? "bg-violet-600 text-white"
+                : "text-neutral-400 hover:text-white"
+            }`}
+          >
+            Propune Poze
+            {pendingCount > 0 && (
+              <span className="ml-2 px-1.5 py-0.5 rounded-full bg-amber-500/30 text-amber-400 text-xs">
+                {pendingCount}
+              </span>
+            )}
+          </button>
+          <button
+            onClick={() => dispatch({ type: "SET_TAB", tab: "gallery" })}
+            className={`flex-1 py-2 px-3 rounded-lg text-sm font-medium transition-colors ${
+              state.tab === "gallery"
+                ? "bg-violet-600 text-white"
+                : "text-neutral-400 hover:text-white"
+            }`}
+          >
+            Galerie Inspirație
+          </button>
+        </div>
+
+        {/* ── TAB: Propune Poze ────────────────────────────────── */}
+        {state.tab === "propose" && (
+          <div className="space-y-5">
+
+            {state.submitSuccess && (
+              <div className="bg-emerald-500/10 border border-emerald-500/30 rounded-xl px-4 py-3">
+                <p className="text-emerald-400 text-sm font-medium">✓ Pozele au fost trimise spre aprobare!</p>
+                <p className="text-emerald-600 text-xs mt-0.5">Vei primi un email după ce sunt revizuite.</p>
+              </div>
+            )}
+
+            {/* File picker */}
+            <div className="space-y-3">
+              <div className="flex items-center gap-3">
+                <button
+                  onClick={() => inputRef.current?.click()}
+                  disabled={state.drafts.length >= 6 || state.submitting}
+                  className="flex items-center gap-2 px-4 py-2.5 rounded-xl border border-neutral-700 text-neutral-300 text-sm hover:border-violet-500 hover:text-violet-300 transition-colors disabled:opacity-40"
+                >
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                    <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+                    <polyline points="17 8 12 3 7 8" />
+                    <line x1="12" y1="3" x2="12" y2="15" />
+                  </svg>
+                  {state.drafts.length === 0 ? "Selectează poze" : `Adaugă mai multe (${state.drafts.length}/6)`}
+                </button>
+                <input
+                  ref={inputRef}
+                  type="file"
+                  accept=".jpg,.jpeg,.png,.webp"
+                  multiple
+                  className="hidden"
+                  onChange={(event) => handlePickFiles(event.target.files)}
+                />
+              </div>
+
+              {state.submitError && (
+                <p className="text-red-400 text-xs bg-red-400/10 border border-red-400/20 rounded-lg px-3 py-2">
+                  {state.submitError}
+                </p>
+              )}
+            </div>
+
+            {/* Draft editor */}
+            {state.drafts.length > 0 && (
+              <>
+                {/* Featured photo */}
+                <div
+                  className="relative rounded-xl overflow-hidden bg-neutral-950"
+                  style={{ aspectRatio: "4/3" }}
+                  onTouchStart={handleTouchStart}
+                  onTouchEnd={handleTouchEnd}
+                >
+                  <img
+                    src={currentDraft.preview}
+                    alt=""
+                    className="w-full h-full object-contain"
+                  />
+
+                  {currentDraft.aiLoading && (
+                    <div className="absolute inset-0 bg-black/70 flex flex-col items-center justify-center gap-3">
+                      <div className="w-8 h-8 border-2 border-violet-400 border-t-transparent rounded-full animate-spin" />
+                      <p className="text-neutral-300 text-xs">Analizează poza...</p>
+                    </div>
+                  )}
+
+                  {currentDraft.progress !== null && !currentDraft.aiLoading && (
+                    <div className="absolute inset-0 bg-black/70 flex flex-col items-center justify-center gap-3">
+                      <p className="text-white font-semibold text-lg">{currentDraft.progress}%</p>
+                      <div className="w-36 bg-neutral-700 rounded-full h-1.5">
+                        <div
+                          className="bg-violet-500 h-1.5 rounded-full transition-all"
+                          style={{ width: `${currentDraft.progress}%` }}
+                        />
+                      </div>
+                    </div>
+                  )}
+
+                  {state.draftIndex > 0 && (
+                    <button
+                      onClick={() => dispatch({ type: "SET_DRAFT_INDEX", index: state.draftIndex - 1 })}
+                      className="absolute left-2 top-1/2 -translate-y-1/2 w-9 h-9 rounded-full bg-black/60 text-white text-xl flex items-center justify-center hover:bg-black/80 transition-colors"
+                    >
+                      ‹
+                    </button>
+                  )}
+                  {state.draftIndex < state.drafts.length - 1 && (
+                    <button
+                      onClick={() => dispatch({ type: "SET_DRAFT_INDEX", index: state.draftIndex + 1 })}
+                      className="absolute right-2 top-1/2 -translate-y-1/2 w-9 h-9 rounded-full bg-black/60 text-white text-xl flex items-center justify-center hover:bg-black/80 transition-colors"
+                    >
+                      ›
+                    </button>
+                  )}
+
+                  {!state.submitting && (
+                    <button
+                      onClick={() => dispatch({ type: "REMOVE_DRAFT", index: state.draftIndex })}
+                      className="absolute top-2 right-2 w-7 h-7 rounded-full bg-red-500/80 text-white text-xs flex items-center justify-center hover:bg-red-500 transition-colors"
+                    >
+                      ✕
+                    </button>
+                  )}
+
+                  <div className="absolute bottom-2 left-1/2 -translate-x-1/2 px-2.5 py-0.5 rounded-full bg-black/60 text-white text-xs">
+                    {state.draftIndex + 1} / {state.drafts.length}
+                  </div>
+                </div>
+
+                {/* Thumbnails */}
+                {state.drafts.length > 1 && (
+                  <div className="flex gap-2 overflow-x-auto pb-1">
+                    {state.drafts.map((draft, index) => (
+                      <button
+                        key={index}
+                        onClick={() => dispatch({ type: "SET_DRAFT_INDEX", index })}
+                        className={`relative shrink-0 w-14 h-14 rounded-lg overflow-hidden border-2 transition-all ${
+                          index === state.draftIndex ? "border-violet-500" : "border-transparent opacity-50 hover:opacity-90"
+                        }`}
+                      >
+                        <img src={draft.preview} alt="" className="w-full h-full object-cover" />
+                      </button>
+                    ))}
+                  </div>
+                )}
+
+                {/* AI button */}
+                <button
+                  onClick={() => suggestAI(state.draftIndex)}
+                  disabled={currentDraft.aiLoading || state.submitting}
+                  className="w-full flex items-center justify-center gap-1.5 px-3 py-2.5 rounded-xl bg-violet-500/15 border border-violet-500/30 text-violet-300 text-xs font-medium hover:bg-violet-500/25 disabled:opacity-40 transition-colors"
+                >
+                  {currentDraft.aiLoading
+                    ? <span className="w-3 h-3 border-2 border-violet-400 border-t-transparent rounded-full animate-spin" />
+                    : <span>✦</span>
+                  }
+                  Sugerează tag-uri AI pentru această poză
+                </button>
+
+                {/* Tags */}
+                <div>
+                  <p className="text-neutral-400 text-xs uppercase tracking-wide font-medium mb-2">
+                    Tag-uri
+                    {currentDraft.tags.length > 0
+                      ? <span className="ml-1.5 text-violet-400 normal-case font-normal">· {currentDraft.tags.length} selectate</span>
+                      : <span className="ml-1.5 text-neutral-600 normal-case font-normal">(opțional)</span>
+                    }
+                  </p>
+                  <div className="flex flex-wrap gap-1.5 max-h-32 overflow-y-auto">
+                    {PRESET_TAGS.map((tag) => (
+                      <TagPill
+                        key={tag}
+                        tag={tag}
+                        selected={currentDraft.tags.includes(tag)}
+                        onClick={() => toggleTag(tag)}
+                      />
+                    ))}
+                  </div>
+                  <div className="flex gap-2 mt-2">
+                    <input
+                      className="flex-1 bg-neutral-800 text-white text-sm border border-neutral-700 rounded-lg px-3 py-1.5 outline-none focus:border-violet-500 transition-colors placeholder-neutral-600"
+                      placeholder="Tag custom..."
+                      value={state.customTag}
+                      onChange={(event) => dispatch({ type: "SET_CUSTOM_TAG", value: event.target.value })}
+                      onKeyDown={(event) => { if (event.key === "Enter") { event.preventDefault(); addCustomTag(); } }}
+                    />
+                    <button
+                      onClick={addCustomTag}
+                      className="px-3 py-1.5 rounded-lg bg-neutral-800 text-neutral-300 text-xs hover:bg-neutral-700 transition-colors"
+                    >
+                      Adaugă
+                    </button>
+                  </div>
+                </div>
+
+                {/* Notes */}
+                <div>
+                  <p className="text-neutral-400 text-xs uppercase tracking-wide font-medium mb-1">
+                    Notă · poza {state.draftIndex + 1}
+                    <span className="normal-case font-normal text-neutral-600 ml-1">(opțional)</span>
+                  </p>
+                  <textarea
+                    className="w-full bg-neutral-800 text-white text-sm border border-neutral-700 rounded-lg px-3 py-2 outline-none focus:border-neutral-500 transition-colors resize-none placeholder-neutral-600"
+                    rows={2}
+                    placeholder="ex: lumină naturală, moment special..."
+                    value={currentDraft.notes}
+                    onChange={(event) =>
+                      dispatch({ type: "UPDATE_DRAFT", index: state.draftIndex, updates: { notes: event.target.value } })
+                    }
+                  />
+                </div>
+
+                {/* Submit */}
+                <button
+                  onClick={handleSubmit}
+                  disabled={state.submitting || state.drafts.length === 0}
+                  className="w-full px-4 py-3 rounded-xl bg-violet-600 text-white text-sm font-semibold hover:bg-violet-500 disabled:opacity-40 transition-colors"
+                >
+                  {state.submitting
+                    ? "Se încarcă și trimite..."
+                    : `Propune ${state.drafts.length} ${state.drafts.length === 1 ? "poză" : "poze"} spre aprobare`
+                  }
+                </button>
+              </>
+            )}
+
+            {/* Past proposals */}
+            {state.proposalsLoading && (
+              <p className="text-neutral-600 text-sm text-center py-4">Se încarcă propunerile...</p>
+            )}
+
+            {!state.proposalsLoading && state.proposals.length > 0 && (
+              <div className="space-y-3">
+                <p className="text-neutral-500 text-xs uppercase tracking-wide font-medium">
+                  Propunerile tale ({state.proposals.length})
+                </p>
+                {state.proposals.map((proposal) => (
+                  <div
+                    key={proposal.id}
+                    className="flex gap-3 items-start bg-neutral-900 border border-neutral-800 rounded-xl p-3"
+                  >
+                    <img
+                      src={proposal.url}
+                      alt=""
+                      className="w-16 h-16 rounded-lg object-cover shrink-0"
+                    />
+                    <div className="min-w-0 flex-1">
+                      <div className="flex items-center gap-2 mb-1">
+                        <StatusBadge status={proposal.status} />
+                        <span className="text-neutral-600 text-xs">
+                          {new Date(proposal.proposedAt).toLocaleDateString("ro-RO")}
+                        </span>
+                      </div>
+                      {proposal.tags.length > 0 && (
+                        <div className="flex flex-wrap gap-1 mt-1">
+                          {proposal.tags.slice(0, 4).map((tag) => (
+                            <span key={tag} className="px-1.5 py-0.5 rounded-full bg-neutral-800 text-neutral-400 text-xs">
+                              {tag}
+                            </span>
+                          ))}
+                          {proposal.tags.length > 4 && (
+                            <span className="text-neutral-600 text-xs">+{proposal.tags.length - 4}</span>
+                          )}
+                        </div>
+                      )}
+                      {proposal.status === "rejected" && proposal.rejectionReason && (
+                        <p className="text-red-400 text-xs mt-1 bg-red-500/10 rounded-lg px-2 py-1">
+                          {proposal.rejectionReason}
+                        </p>
+                      )}
+                      {proposal.status === "rejected" && !proposal.rejectionReason && (
+                        <p className="text-red-400/60 text-xs mt-1">
+                          Poza nu corespunde stilului galeriei.
+                        </p>
+                      )}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* ── TAB: Galerie Inspirație ──────────────────────────── */}
+        {state.tab === "gallery" && (
+          <div>
+            {state.galleryLoading && <AncaLoader />}
+            {!state.galleryLoading && state.galleryPhotos.length === 0 && (
+              <p className="text-neutral-600 text-sm text-center py-10">
+                Galeria e goală momentan.
+              </p>
+            )}
+            {!state.galleryLoading && state.galleryPhotos.length > 0 && (
+              <>
+                <p className="text-neutral-500 text-sm mb-4">
+                  {state.galleryPhotos.length} poze în galerie
+                </p>
+                <div style={{ columns: "2 140px", columnGap: "8px" }}>
+                  {state.galleryPhotos.map((photo) => (
+                    <div
+                      key={photo.id}
+                      className="relative rounded-xl overflow-hidden border border-neutral-800 mb-2 break-inside-avoid"
+                    >
+                      <img
+                        src={photo.url}
+                        alt=""
+                        className="w-full h-auto block"
+                        loading="lazy"
+                      />
+                      {photo.tags.length > 0 && (
+                        <div className="absolute bottom-0 left-0 right-0 p-1.5 flex flex-wrap gap-1 bg-gradient-to-t from-black/60 to-transparent">
+                          {photo.tags.slice(0, 2).map((tag) => (
+                            <span key={tag} className="px-1.5 py-0.5 rounded-full bg-black/60 text-white text-xs">
+                              {tag}
+                            </span>
+                          ))}
+                        </div>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              </>
+            )}
+          </div>
+        )}
+
+      </div>
+    </div>
+  );
+}

--- a/src/client/hooks/useBodyScrollLock.ts
+++ b/src/client/hooks/useBodyScrollLock.ts
@@ -1,0 +1,12 @@
+import { useEffect } from "react";
+
+export function useBodyScrollLock(locked: boolean) {
+  useEffect(() => {
+    if (!locked) return;
+    const previous = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = previous;
+    };
+  }, [locked]);
+}

--- a/src/client/pages/MediaDownload/MediaConsentModal.tsx
+++ b/src/client/pages/MediaDownload/MediaConsentModal.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef } from "react";
+import { useBodyScrollLock } from "../../hooks/useBodyScrollLock";
 
 const CONSENT_KEY_PREFIX = "av:consent:";
 const ADMIN_BYPASS_KEY = "av:consent:admin:bypass";
@@ -13,6 +14,7 @@ export default function MediaConsentModal({ slug, onAccepted }: Props) {
   const consentKey = CONSENT_KEY_PREFIX + slug;
 
   const [phase, setPhase] = useState<"hidden" | "modal" | "banner">("hidden");
+  useBodyScrollLock(phase === "modal");
   const [checked, setChecked] = useState(false);
   const [loading, setLoading] = useState(false);
   const [collapsed, setCollapsed] = useState(false);

--- a/src/client/pages/MediaDownload/PhotoLightbox.tsx
+++ b/src/client/pages/MediaDownload/PhotoLightbox.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useCallback } from 'react';
+import { useBodyScrollLock } from '../../hooks/useBodyScrollLock';
 import styles from './PhotoLightbox.module.scss';
 
 type PhotoLightboxProps = {
@@ -24,6 +25,7 @@ export default function PhotoLightbox({
   onTogglePrint,
   getFileName,
 }: PhotoLightboxProps) {
+  useBodyScrollLock(true);
   const touchStartXRef = useRef<number | null>(null);
   const touchStartYRef = useRef<number | null>(null);
   const mouseStartXRef = useRef<number | null>(null);

--- a/src/server/notifications/templates/inspirationProposalTemplate.ts
+++ b/src/server/notifications/templates/inspirationProposalTemplate.ts
@@ -1,0 +1,98 @@
+import { sendEmail } from "../mailer";
+import { adminUser } from "../../constants/credentials";
+
+const brandHeader = `
+  <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto; padding: 40px 20px; background: #fff;">
+    <div style="text-align: center; margin-bottom: 24px;">
+      <h2 style="color: #c9a96e; font-weight: 300; letter-spacing: 3px; font-size: 20px; margin: 0;">ANCA VISUALS</h2>
+      <p style="color: #999; font-size: 11px; letter-spacing: 1px; margin: 4px 0 0; text-transform: uppercase;">Fotografie &amp; Videografie</p>
+    </div>
+    <hr style="border: none; border-top: 1px solid #c9a96e; margin: 0 0 28px;" />
+`;
+
+const brandFooter = `
+    <p style="color: #aaa; font-size: 11px; text-align: center; margin-top: 32px;">Anca Visuals · ancavisuals.ro</p>
+  </div>
+`;
+
+interface ProposalSubmittedOptions {
+  proposerEmail: string;
+  photoCount: number;
+}
+
+export async function sendInspirationProposalSubmittedEmail(options: ProposalSubmittedOptions): Promise<void> {
+  const { proposerEmail, photoCount } = options;
+  const reviewLink = "https://ancavisuals.ro/admin/inspiration";
+
+  await sendEmail({
+    to: adminUser.email,
+    subject: `[Inspirație] ${photoCount} ${photoCount === 1 ? "poză propusă" : "poze propuse"} de ${proposerEmail}`,
+    html: `
+      ${brandHeader}
+      <p style="color: #333; margin-bottom: 12px;">
+        <strong>${proposerEmail}</strong> a propus
+        <strong>${photoCount} ${photoCount === 1 ? "poză" : "poze"}</strong> pentru galeria de inspirație.
+      </p>
+      <div style="text-align: center; margin: 28px 0;">
+        <a href="${reviewLink}"
+           style="display: inline-block; padding: 14px 32px; background: #c9a96e; color: #fff; text-decoration: none; border-radius: 4px; font-size: 15px; letter-spacing: 1px;">
+          Revizuiește propunerile
+        </a>
+      </div>
+      ${brandFooter}
+    `,
+  });
+}
+
+interface ProposalReviewOptions {
+  to: string;
+  action: "approve" | "reject";
+  photoUrl: string;
+  rejectionReason: string;
+}
+
+export async function sendInspirationProposalReviewEmail(options: ProposalReviewOptions): Promise<void> {
+  const { to, action, photoUrl, rejectionReason } = options;
+
+  if (action === "approve") {
+    await sendEmail({
+      to,
+      subject: "[Inspirație] Poza ta a fost acceptată! ✓",
+      html: `
+        ${brandHeader}
+        <p style="color: #333; margin-bottom: 16px;">
+          Felicitări! Poza ta propusă a fost <strong style="color: #16a34a;">acceptată</strong> și a fost adăugată în galeria de inspirație.
+        </p>
+        <div style="text-align: center; margin: 20px 0;">
+          <img src="${photoUrl}" alt="Poza acceptată" style="max-width: 100%; max-height: 300px; border-radius: 8px; border: 2px solid #16a34a;" />
+        </div>
+        ${brandFooter}
+      `,
+    });
+  } else {
+    const reason = rejectionReason.trim()
+      ? rejectionReason
+      : "Poza nu corespunde stilului galeriei de inspirație.";
+
+    await sendEmail({
+      to,
+      subject: "[Inspirație] Poza ta nu a fost acceptată",
+      html: `
+        ${brandHeader}
+        <p style="color: #333; margin-bottom: 16px;">
+          Din păcate, poza ta propusă nu a fost acceptată în galeria de inspirație.
+        </p>
+        <div style="text-align: center; margin: 20px 0;">
+          <img src="${photoUrl}" alt="Poza respinsă" style="max-width: 100%; max-height: 300px; border-radius: 8px; border: 2px solid #dc2626;" />
+        </div>
+        <div style="background: #fef2f2; border: 1px solid #fca5a5; border-radius: 8px; padding: 14px 16px; margin-bottom: 16px;">
+          <p style="color: #991b1b; font-size: 13px; margin: 0;">
+            <strong>Motiv:</strong> ${reason}
+          </p>
+        </div>
+        <p style="color: #555; font-size: 13px;">Poți propune alte poze oricând din secțiunea "Propune Poze".</p>
+        ${brandFooter}
+      `,
+    });
+  }
+}

--- a/src/server/routes/inspiration-proposals.routes.ts
+++ b/src/server/routes/inspiration-proposals.routes.ts
@@ -1,0 +1,187 @@
+import type { Request, Response } from "express";
+import { Router } from "express";
+import { Timestamp } from "firebase-admin/firestore";
+import { firestore } from "../firestore";
+import { requireFirebaseAuth, requireSupremeAdmin } from "../middleware/requireFirebaseAuth";
+import type { AuthenticatedRequest } from "../middleware/requireFirebaseAuth";
+import {
+  sendInspirationProposalSubmittedEmail,
+  sendInspirationProposalReviewEmail,
+} from "../notifications/templates/inspirationProposalTemplate";
+
+const router = Router();
+
+const PROPOSALS_COLLECTION = "inspirationProposals";
+const INSPIRATION_COLLECTION = "inspirationPhotos";
+
+// POST /propose — collaborator submits 1-6 photos
+router.post("/propose", requireFirebaseAuth, async (req: Request, res: Response) => {
+  const authReq = req as AuthenticatedRequest;
+  const { photos } = req.body as {
+    photos: Array<{ url: string; tags: string[]; notes: string }>;
+  };
+
+  if (!Array.isArray(photos) || photos.length === 0 || photos.length > 6) {
+    res.status(400).json({ error: "Trimite între 1 și 6 poze." });
+    return;
+  }
+
+  try {
+    const db = firestore();
+    const batch = db.batch();
+    for (const photo of photos) {
+      const docRef = db.collection(PROPOSALS_COLLECTION).doc();
+      batch.set(docRef, {
+        proposedByEmail: authReq.firebaseEmail,
+        proposedByUid: authReq.firebaseUid,
+        url: photo.url,
+        tags: Array.isArray(photo.tags) ? photo.tags : [],
+        notes: photo.notes ?? "",
+        status: "pending",
+        rejectionReason: "",
+        proposedAt: Timestamp.now(),
+        reviewedAt: null,
+      });
+    }
+    await batch.commit();
+
+    sendInspirationProposalSubmittedEmail({
+      proposerEmail: authReq.firebaseEmail,
+      photoCount: photos.length,
+    }).catch((err) => console.error("[inspiration-proposals] Submitted email failed:", err));
+
+    res.json({ ok: true, submitted: photos.length });
+  } catch (error) {
+    console.error("[inspiration-proposals] POST /propose failed:", error);
+    res.status(500).json({ error: String(error) });
+  }
+});
+
+// GET /my — collaborator sees own proposals (pending + approved + rejected)
+router.get("/my", requireFirebaseAuth, async (req: Request, res: Response) => {
+  const authReq = req as AuthenticatedRequest;
+  try {
+    const db = firestore();
+    const snapshot = await db
+      .collection(PROPOSALS_COLLECTION)
+      .where("proposedByUid", "==", authReq.firebaseUid)
+      .orderBy("proposedAt", "desc")
+      .get();
+
+    const proposals = snapshot.docs.map((doc) => {
+      const data = doc.data();
+      return {
+        id: doc.id,
+        url: data.url as string,
+        tags: data.tags as string[],
+        notes: data.notes as string,
+        status: data.status as string,
+        rejectionReason: data.rejectionReason as string,
+        proposedAt: (data.proposedAt as Timestamp).toDate().toISOString(),
+        reviewedAt: data.reviewedAt ? (data.reviewedAt as Timestamp).toDate().toISOString() : null,
+      };
+    });
+
+    res.json({ proposals });
+  } catch (error) {
+    console.error("[inspiration-proposals] GET /my failed:", error);
+    res.status(500).json({ error: String(error) });
+  }
+});
+
+// GET /admin/pending-count — for dashboard badge
+router.get("/admin/pending-count", requireFirebaseAuth, requireSupremeAdmin, async (_req: Request, res: Response) => {
+  try {
+    const db = firestore();
+    const snapshot = await db
+      .collection(PROPOSALS_COLLECTION)
+      .where("status", "==", "pending")
+      .get();
+    res.json({ pendingCount: snapshot.size });
+  } catch (error) {
+    console.error("[inspiration-proposals] GET /admin/pending-count failed:", error);
+    res.status(500).json({ error: String(error) });
+  }
+});
+
+// GET /admin/pending — admin sees all pending proposals
+router.get("/admin/pending", requireFirebaseAuth, requireSupremeAdmin, async (_req: Request, res: Response) => {
+  try {
+    const db = firestore();
+    const snapshot = await db
+      .collection(PROPOSALS_COLLECTION)
+      .where("status", "==", "pending")
+      .orderBy("proposedAt", "asc")
+      .get();
+
+    const proposals = snapshot.docs.map((doc) => {
+      const data = doc.data();
+      return {
+        id: doc.id,
+        url: data.url as string,
+        tags: data.tags as string[],
+        notes: data.notes as string,
+        proposedByEmail: data.proposedByEmail as string,
+        proposedAt: (data.proposedAt as Timestamp).toDate().toISOString(),
+      };
+    });
+
+    res.json({ proposals });
+  } catch (error) {
+    console.error("[inspiration-proposals] GET /admin/pending failed:", error);
+    res.status(500).json({ error: String(error) });
+  }
+});
+
+// POST /admin/review/:id — admin approves or rejects a proposal
+router.post("/admin/review/:id", requireFirebaseAuth, requireSupremeAdmin, async (req: Request, res: Response) => {
+  const { id } = req.params;
+  const { action, rejectionReason } = req.body as {
+    action: "approve" | "reject";
+    rejectionReason?: string;
+  };
+
+  if (action !== "approve" && action !== "reject") {
+    res.status(400).json({ error: "action must be approve or reject" });
+    return;
+  }
+
+  try {
+    const db = firestore();
+    const proposalDoc = await db.collection(PROPOSALS_COLLECTION).doc(id).get();
+    if (!proposalDoc.exists) {
+      res.status(404).json({ error: "Propunerea nu a fost găsită." });
+      return;
+    }
+    const proposal = proposalDoc.data()!;
+
+    await proposalDoc.ref.update({
+      status: action === "approve" ? "approved" : "rejected",
+      rejectionReason: rejectionReason ?? "",
+      reviewedAt: Timestamp.now(),
+    });
+
+    if (action === "approve") {
+      await db.collection(INSPIRATION_COLLECTION).add({
+        url: proposal.url as string,
+        tags: proposal.tags ?? [],
+        notes: proposal.notes ?? "",
+        uploadedAt: Timestamp.now(),
+      });
+    }
+
+    sendInspirationProposalReviewEmail({
+      to: proposal.proposedByEmail as string,
+      action,
+      photoUrl: proposal.url as string,
+      rejectionReason: rejectionReason ?? "",
+    }).catch((err) => console.error("[inspiration-proposals] Review email failed:", err));
+
+    res.json({ ok: true });
+  } catch (error) {
+    console.error("[inspiration-proposals] POST /admin/review failed:", error);
+    res.status(500).json({ error: String(error) });
+  }
+});
+
+export default router;

--- a/src/server/routes/inspiration.routes.ts
+++ b/src/server/routes/inspiration.routes.ts
@@ -115,19 +115,14 @@ RULES:
 2. Use tags from the reference list above when they match accurately.
 3. Add extra descriptive tags (not in the list) for anything specific you notice — keep them lowercase, no diacritics, hyphenated.
 4. Return 4–8 tags total, ordered from most to least relevant.
-5. Reply with ONLY a JSON array, no explanation.`,
+5. Reply with ONLY a JSON array, no explanation. Example: ["mire", "mireasa", "biserica"]`,
             },
           ],
-        },
-        {
-          role: "assistant",
-          content: "[",
         },
       ],
     });
 
-    const rawSuffix = message.content[0].type === "text" ? message.content[0].text.trim() : "]";
-    const raw = "[" + rawSuffix;
+    const raw = message.content[0].type === "text" ? message.content[0].text.trim() : "[]";
     const match = raw.match(/\[[\s\S]*?\]/);
     const generatedTags: string[] = match ? JSON.parse(match[0]) : [];
 


### PR DESCRIPTION
  - New /colaborator page (2 tabs: propose photos + view gallery)
  - Collaborators upload up to 6 photos at a time to Firebase Storage under inspiration-proposals/{uid}/; optional tags (with AI suggest) and notes per photo
  - New inspirationProposals Firestore collection with pending/approved/rejected status reject each photo individually with optional rejection reason
  - On approve: photo is added automatically to inspirationPhotos collection
  - On reject: collaborator receives email with the photo and reason
  - Admin receives email + amber badge on Dashboard "Inspirație" button when new proposals arrive
  - Link from ModeratorAlbumsPage to /colaborator so collaborators find it after login
  - Fix UploadModal closing after first photo instead of all photos
  - Fix AI tag suggestion HTTP 500 (remove assistant prefill from suggest-tags-from-image endpoint, incompatible with claude-sonnet-4-6)

  Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>