### PR TITLE
feat: onboarding tutorial, contract reminders, analytics improvements

### DIFF
--- a/src/client/features/admin/components/AnalyticsPage.tsx
+++ b/src/client/features/admin/components/AnalyticsPage.tsx
@@ -20,11 +20,12 @@ interface Visit {
 
 interface Stats {
   today: { visitors: number };
+  threeDays: { visitors: number };
   week: { visitors: number };
   month: { visitors: number };
-  halfYear: { visitors: number };
-  year: { visitors: number };
+  threeMonths: { visitors: number };
   topPages: { page: string; count: number }[];
+  topReferrers: { referrer: string; count: number }[];
   topCountries: { country: string; count: number }[];
 }
 
@@ -49,6 +50,16 @@ interface Visitor {
   returnedToday: boolean;
 }
 
+type PeriodKey = "today" | "3d" | "7d" | "30d" | "90d";
+
+const PERIODS: { key: PeriodKey; label: string; statKey: keyof Stats; days: number }[] = [
+  { key: "today", label: "Azi",    statKey: "today",       days: 0  },
+  { key: "3d",    label: "3 zile", statKey: "threeDays",   days: 3  },
+  { key: "7d",    label: "7 zile", statKey: "week",        days: 7  },
+  { key: "30d",   label: "1 lună", statKey: "month",       days: 30 },
+  { key: "90d",   label: "3 luni", statKey: "threeMonths", days: 90 },
+];
+
 function parseDevice(ua: string): string {
   if (!ua) return "Necunoscut";
   const mobile = /android|iphone|ipad|mobile/i.test(ua);
@@ -66,8 +77,7 @@ function timeAgo(iso: string): string {
   if (m < 60) return `${m}min`;
   const h = Math.floor(m / 60);
   if (h < 24) return `${h}h`;
-  const d = Math.floor(h / 24);
-  return `${d}z`;
+  return `${Math.floor(h / 24)}z`;
 }
 
 function formatTime(iso: string): string {
@@ -93,43 +103,51 @@ function isSameDay(a: string, b: string): boolean {
     da.getDate() === db.getDate();
 }
 
+function periodCutoff(period: PeriodKey): Date {
+  const now = new Date();
+  if (period === "today") {
+    return new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  }
+  const days = PERIODS.find((p) => p.key === period)!.days;
+  const cutoff = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  cutoff.setDate(cutoff.getDate() - (days - 1));
+  return cutoff;
+}
+
 function groupByVisitors(visits: Visit[]): Visitor[] {
   const visitorMap = new Map<string, Visitor>();
   const sessionMap = new Map<string, SessionEntry>();
 
-  // Build sessions first
-  for (const v of visits) {
-    const sid = v.sessionId || v.id;
+  for (const visit of visits) {
+    const sid = visit.sessionId || visit.id;
     if (!sessionMap.has(sid)) {
-      sessionMap.set(sid, { sessionId: sid, pages: [], firstSeen: v.timestamp, lastSeen: v.timestamp });
+      sessionMap.set(sid, { sessionId: sid, pages: [], firstSeen: visit.timestamp, lastSeen: visit.timestamp });
     }
-    const s = sessionMap.get(sid)!;
-    s.pages.push({ page: v.page, timestamp: v.timestamp });
-    if (v.timestamp < s.firstSeen) s.firstSeen = v.timestamp;
-    if (v.timestamp > s.lastSeen) s.lastSeen = v.timestamp;
+    const session = sessionMap.get(sid)!;
+    session.pages.push({ page: visit.page, timestamp: visit.timestamp });
+    if (visit.timestamp < session.firstSeen) session.firstSeen = visit.timestamp;
+    if (visit.timestamp > session.lastSeen) session.lastSeen = visit.timestamp;
   }
 
-  // Sort pages within each session
-  for (const s of sessionMap.values()) {
-    s.pages.sort((a, b) => a.timestamp.localeCompare(b.timestamp));
+  for (const session of sessionMap.values()) {
+    session.pages.sort((a, b) => a.timestamp.localeCompare(b.timestamp));
   }
 
-  // Group sessions by visitorId (fallback to sessionId if no visitorId)
-  for (const v of visits) {
-    const vid = v.visitorId || v.sessionId;
-    const sid = v.sessionId || v.id;
+  for (const visit of visits) {
+    const vid = visit.visitorId || visit.sessionId;
+    const sid = visit.sessionId || visit.id;
     if (!visitorMap.has(vid)) {
       visitorMap.set(vid, {
         visitorId: vid,
-        isNew: v.isNew,
-        ip: v.ip,
-        city: v.city,
-        country: v.country,
-        org: v.org,
-        userAgent: v.userAgent,
+        isNew: visit.isNew,
+        ip: visit.ip,
+        city: visit.city,
+        country: visit.country,
+        org: visit.org,
+        userAgent: visit.userAgent,
         sessions: [],
-        firstSeen: v.timestamp,
-        lastSeen: v.timestamp,
+        firstSeen: visit.timestamp,
+        lastSeen: visit.timestamp,
         returnedToday: false,
       });
     }
@@ -138,29 +156,17 @@ function groupByVisitors(visits: Visit[]): Visitor[] {
     if (!visitor.sessions.find((s) => s.sessionId === sid)) {
       visitor.sessions.push(session);
     }
-    if (v.timestamp < visitor.firstSeen) visitor.firstSeen = v.timestamp;
-    if (v.timestamp > visitor.lastSeen) visitor.lastSeen = v.timestamp;
+    if (visit.timestamp < visitor.firstSeen) visitor.firstSeen = visit.timestamp;
+    if (visit.timestamp > visitor.lastSeen) visitor.lastSeen = visit.timestamp;
   }
 
   const today = new Date().toISOString();
   for (const visitor of visitorMap.values()) {
     visitor.sessions.sort((a, b) => a.firstSeen.localeCompare(b.firstSeen));
-    // Returned today = has more than 1 session and at least 2 of them are today
-    const todaySessions = visitor.sessions.filter((s) => isSameDay(s.firstSeen, today));
-    visitor.returnedToday = todaySessions.length > 1;
+    visitor.returnedToday = visitor.sessions.filter((s) => isSameDay(s.firstSeen, today)).length > 1;
   }
 
   return Array.from(visitorMap.values()).sort((a, b) => b.lastSeen.localeCompare(a.lastSeen));
-}
-
-function StatCard({ label, value }: { label: string; value: number }) {
-  return (
-    <div className="bg-neutral-900 border border-neutral-800 rounded-xl p-4">
-      <p className="text-neutral-500 text-xs uppercase tracking-wider mb-2">{label}</p>
-      <p className="text-white text-2xl font-light">{value}</p>
-      <p className="text-neutral-700 text-[10px] mt-1">vizitatori unici</p>
-    </div>
-  );
 }
 
 export default function AnalyticsPage() {
@@ -169,11 +175,12 @@ export default function AnalyticsPage() {
   const [stats, setStats] = useState<Stats | null>(null);
   const [loading, setLoading] = useState(true);
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  const [period, setPeriod] = useState<PeriodKey>("7d");
 
   const load = () => {
     setLoading(true);
     Promise.all([
-      fetch("/api/admin/analytics/visits?limit=1000").then((r) => r.json()),
+      fetch("/api/admin/analytics/visits?limit=2000").then((r) => r.json()),
       fetch("/api/admin/analytics/stats").then((r) => r.json()),
     ])
       .then(([visitsData, statsData]) => {
@@ -185,7 +192,14 @@ export default function AnalyticsPage() {
 
   useEffect(() => { load(); }, []);
 
-  const visitors = useMemo(() => groupByVisitors(visits), [visits]);
+  const cutoff = useMemo(() => periodCutoff(period), [period]);
+
+  const filteredVisits = useMemo(
+    () => visits.filter((v) => new Date(v.timestamp) >= cutoff),
+    [visits, cutoff],
+  );
+
+  const visitors = useMemo(() => groupByVisitors(filteredVisits), [filteredVisits]);
 
   function toggleExpanded(id: string) {
     setExpanded((prev) => {
@@ -196,6 +210,9 @@ export default function AnalyticsPage() {
   }
 
   if (loading) return <AncaLoader />;
+
+  const activePeriod = PERIODS.find((p) => p.key === period)!;
+  const activeCount = stats ? (stats[activePeriod.statKey] as { visitors: number }).visitors : 0;
 
   return (
     <div className="min-h-screen bg-neutral-950 px-4 py-10">
@@ -214,7 +231,9 @@ export default function AnalyticsPage() {
         <div className="flex items-center justify-between">
           <div>
             <h1 className="text-white text-2xl font-light tracking-tight">Analytics</h1>
-            <p className="text-neutral-500 text-sm mt-1">{visitors.length} vizitatori unici</p>
+            <p className="text-neutral-500 text-sm mt-1">
+              {activeCount} vizitatori unici · {activePeriod.label.toLowerCase()}
+            </p>
           </div>
           <button
             onClick={load}
@@ -228,24 +247,39 @@ export default function AnalyticsPage() {
           </button>
         </div>
 
-        {/* Stats */}
+        {/* Period tabs — also stat cards */}
         {stats && (
-          <div className="grid grid-cols-3 gap-3 sm:grid-cols-5">
-            <StatCard label="Azi" value={stats.today.visitors} />
-            <StatCard label="7 zile" value={stats.week.visitors} />
-            <StatCard label="30 zile" value={stats.month.visitors} />
-            <StatCard label="6 luni" value={stats.halfYear.visitors} />
-            <StatCard label="1 an" value={stats.year.visitors} />
+          <div className="grid grid-cols-5 gap-2">
+            {PERIODS.map(({ key, label, statKey }) => {
+              const count = (stats[statKey] as { visitors: number }).visitors;
+              const isActive = period === key;
+              return (
+                <button
+                  key={key}
+                  onClick={() => setPeriod(key)}
+                  className={`rounded-xl p-3 text-left border transition-all ${
+                    isActive
+                      ? "bg-violet-500/10 border-violet-500/40"
+                      : "bg-neutral-900 border-neutral-800 hover:border-neutral-700"
+                  }`}
+                >
+                  <p className={`text-[10px] uppercase tracking-wider mb-1.5 ${isActive ? "text-violet-400" : "text-neutral-500"}`}>
+                    {label}
+                  </p>
+                  <p className={`text-xl font-light ${isActive ? "text-white" : "text-neutral-300"}`}>{count}</p>
+                </button>
+              );
+            })}
           </div>
         )}
 
-        {/* Top pages + countries */}
+        {/* Top pages + countries + referrers */}
         {stats && (
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-            <div className="bg-neutral-900 border border-neutral-800 rounded-xl p-5">
-              <p className="text-neutral-400 text-xs uppercase tracking-wider mb-3">Top Pagini (7 zile)</p>
-              <div className="space-y-2">
-                {stats.topPages.map(({ page, count }) => (
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+            <div className="bg-neutral-900 border border-neutral-800 rounded-xl p-4">
+              <p className="text-neutral-400 text-[10px] uppercase tracking-wider mb-3">Top pagini · 30 zile</p>
+              <div className="space-y-1.5">
+                {stats.topPages.slice(0, 8).map(({ page, count }) => (
                   <div key={page} className="flex items-center gap-2">
                     <span className="text-neutral-300 text-xs font-mono truncate flex-1">{page}</span>
                     <span className="text-violet-400 text-xs font-semibold flex-shrink-0">{count}</span>
@@ -253,9 +287,9 @@ export default function AnalyticsPage() {
                 ))}
               </div>
             </div>
-            <div className="bg-neutral-900 border border-neutral-800 rounded-xl p-5">
-              <p className="text-neutral-400 text-xs uppercase tracking-wider mb-3">Top Țări (7 zile)</p>
-              <div className="space-y-2">
+            <div className="bg-neutral-900 border border-neutral-800 rounded-xl p-4">
+              <p className="text-neutral-400 text-[10px] uppercase tracking-wider mb-3">Top țări · 30 zile</p>
+              <div className="space-y-1.5">
                 {stats.topCountries.map(({ country, count }) => (
                   <div key={country} className="flex items-center gap-2">
                     <span className="text-neutral-300 text-xs flex-1">{country || "Necunoscut"}</span>
@@ -264,133 +298,139 @@ export default function AnalyticsPage() {
                 ))}
               </div>
             </div>
+            <div className="bg-neutral-900 border border-neutral-800 rounded-xl p-4">
+              <p className="text-neutral-400 text-[10px] uppercase tracking-wider mb-3">Surse trafic · 30 zile</p>
+              <div className="space-y-1.5">
+                {stats.topReferrers.length === 0 ? (
+                  <p className="text-neutral-600 text-xs">Fără trafic extern</p>
+                ) : stats.topReferrers.map(({ referrer, count }) => (
+                  <div key={referrer} className="flex items-center gap-2">
+                    <span className="text-neutral-300 text-xs truncate flex-1">{referrer}</span>
+                    <span className="text-amber-400 text-xs font-semibold flex-shrink-0">{count}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
           </div>
         )}
 
         {/* Visitor feed */}
-        {visitors.length === 0 ? (
-          <div className="text-center py-20">
-            <p className="text-neutral-500 text-sm">Niciun vizitator înregistrat.</p>
-          </div>
-        ) : (
-          <div className="space-y-2">
-            {visitors.map((visitor) => {
-              const isOpen = expanded.has(visitor.visitorId);
-              const location = [visitor.city, visitor.country].filter(Boolean).join(", ");
-              const device = parseDevice(visitor.userAgent);
-              const totalPages = visitor.sessions.reduce((acc, s) => acc + s.pages.length, 0);
-              const totalDuration = visitor.sessions.length > 0
-                ? formatDuration(visitor.firstSeen, visitor.lastSeen)
-                : null;
+        <div>
+          <p className="text-neutral-600 text-xs uppercase tracking-wider mb-3">
+            {visitors.length} vizitatori · {activePeriod.label.toLowerCase()}
+          </p>
 
-              return (
-                <div key={visitor.visitorId} className="rounded-xl bg-neutral-900 border border-neutral-800 overflow-hidden">
-                  {/* Visitor header */}
-                  <button
-                    onClick={() => toggleExpanded(visitor.visitorId)}
-                    className="w-full flex items-start gap-3 p-4 text-left hover:bg-neutral-800/50 transition-colors"
-                  >
-                    {/* Icon */}
-                    <div className="w-8 h-8 rounded-full bg-violet-500/10 border border-violet-500/20 flex items-center justify-center flex-shrink-0 mt-0.5">
-                      <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="#a78bfa" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                        <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" /><circle cx="12" cy="7" r="4" />
-                      </svg>
-                    </div>
+          {visitors.length === 0 ? (
+            <div className="text-center py-16 bg-neutral-900 border border-neutral-800 rounded-xl">
+              <p className="text-neutral-500 text-sm">Niciun vizitator în perioada selectată.</p>
+            </div>
+          ) : (
+            <div className="space-y-2">
+              {visitors.map((visitor) => {
+                const isOpen = expanded.has(visitor.visitorId);
+                const location = [visitor.city, visitor.country].filter(Boolean).join(", ");
+                const device = parseDevice(visitor.userAgent);
+                const totalPages = visitor.sessions.reduce((acc, s) => acc + s.pages.length, 0);
+                const totalDuration = visitor.sessions.length > 0
+                  ? formatDuration(visitor.firstSeen, visitor.lastSeen)
+                  : null;
 
-                    {/* Info */}
-                    <div className="flex-1 min-w-0">
-                      <div className="flex items-center gap-2 flex-wrap">
-                        <span className="text-white text-sm font-medium">
-                          {location || visitor.ip || "Locație necunoscută"}
-                        </span>
-                        {/* Badges */}
-                        {visitor.isNew ? (
-                          <span className="px-1.5 py-0.5 rounded text-[10px] font-medium bg-emerald-500/10 text-emerald-400 border border-emerald-500/20">nou</span>
-                        ) : (
-                          <span className="px-1.5 py-0.5 rounded text-[10px] font-medium bg-amber-500/10 text-amber-400 border border-amber-500/20">revenit</span>
-                        )}
-                        {visitor.returnedToday && (
-                          <span className="px-1.5 py-0.5 rounded text-[10px] font-medium bg-blue-500/10 text-blue-400 border border-blue-500/20">revenit azi</span>
-                        )}
-                        <span className="text-neutral-600 text-xs">·</span>
-                        <span className="text-neutral-500 text-xs">{device}</span>
+                return (
+                  <div key={visitor.visitorId} className="rounded-xl bg-neutral-900 border border-neutral-800 overflow-hidden">
+                    <button
+                      onClick={() => toggleExpanded(visitor.visitorId)}
+                      className="w-full flex items-start gap-3 p-4 text-left hover:bg-neutral-800/50 transition-colors"
+                    >
+                      <div className="w-8 h-8 rounded-full bg-violet-500/10 border border-violet-500/20 flex items-center justify-center flex-shrink-0 mt-0.5">
+                        <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="#a78bfa" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                          <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" /><circle cx="12" cy="7" r="4" />
+                        </svg>
                       </div>
-                      <div className="flex items-center gap-2 mt-1 flex-wrap">
-                        <span className="text-neutral-600 text-xs font-mono">{visitor.ip || "—"}</span>
-                        <span className="text-neutral-700 text-xs">·</span>
-                        <span className="text-violet-400 text-xs">
-                          {visitor.sessions.length > 1
-                            ? `${visitor.sessions.length} vizite · ${totalPages} pagini`
-                            : `${totalPages} ${totalPages === 1 ? "pagină" : "pagini"}`}
-                        </span>
-                        {totalDuration && (
-                          <>
-                            <span className="text-neutral-700 text-xs">·</span>
-                            <span className="text-neutral-600 text-xs">{totalDuration}</span>
-                          </>
-                        )}
-                      </div>
-                    </div>
 
-                    {/* Time + chevron */}
-                    <div className="text-right flex-shrink-0 flex flex-col items-end gap-1">
-                      <span className="text-neutral-400 text-xs">{timeAgo(visitor.lastSeen)}</span>
-                      <svg
-                        width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"
-                        strokeLinecap="round" strokeLinejoin="round"
-                        className={`text-neutral-600 transition-transform ${isOpen ? "rotate-180" : ""}`}
-                      >
-                        <polyline points="6 9 12 15 18 9" />
-                      </svg>
-                    </div>
-                  </button>
-
-                  {/* Timeline expandat */}
-                  {isOpen && (
-                    <div className="border-t border-neutral-800 px-4 py-4 space-y-5">
-                      {visitor.sessions.map((session, si) => (
-                        <div key={session.sessionId}>
-                          {/* Session label if there are multiple */}
-                          {visitor.sessions.length > 1 && (
-                            <p className="text-neutral-600 text-[10px] uppercase tracking-wider mb-2">
-                              Vizita {si + 1} · {formatTime(session.firstSeen)}
-                              {session.pages.length > 1 && ` · ${formatDuration(session.firstSeen, session.lastSeen)}`}
-                            </p>
+                      <div className="flex-1 min-w-0">
+                        <div className="flex items-center gap-2 flex-wrap">
+                          <span className="text-white text-sm font-medium">
+                            {location || visitor.ip || "Locație necunoscută"}
+                          </span>
+                          {visitor.isNew ? (
+                            <span className="px-1.5 py-0.5 rounded text-[10px] font-medium bg-emerald-500/10 text-emerald-400 border border-emerald-500/20">nou</span>
+                          ) : (
+                            <span className="px-1.5 py-0.5 rounded text-[10px] font-medium bg-amber-500/10 text-amber-400 border border-amber-500/20">revenit</span>
                           )}
+                          {visitor.returnedToday && (
+                            <span className="px-1.5 py-0.5 rounded text-[10px] font-medium bg-blue-500/10 text-blue-400 border border-blue-500/20">revenit azi</span>
+                          )}
+                          <span className="text-neutral-600 text-xs">·</span>
+                          <span className="text-neutral-500 text-xs">{device}</span>
+                        </div>
+                        <div className="flex items-center gap-2 mt-1 flex-wrap">
+                          <span className="text-neutral-600 text-xs font-mono">{visitor.ip || "—"}</span>
+                          <span className="text-neutral-700 text-xs">·</span>
+                          <span className="text-violet-400 text-xs">
+                            {visitor.sessions.length > 1
+                              ? `${visitor.sessions.length} vizite · ${totalPages} pagini`
+                              : `${totalPages} ${totalPages === 1 ? "pagină" : "pagini"}`}
+                          </span>
+                          {totalDuration && (
+                            <>
+                              <span className="text-neutral-700 text-xs">·</span>
+                              <span className="text-neutral-600 text-xs">{totalDuration}</span>
+                            </>
+                          )}
+                        </div>
+                      </div>
 
-                          {/* Timeline pagini */}
-                          <div className="relative pl-4">
-                            {/* Vertical line */}
-                            <div className="absolute left-[5px] top-2 bottom-2 w-px bg-neutral-800" />
+                      <div className="text-right flex-shrink-0 flex flex-col items-end gap-1">
+                        <span className="text-neutral-400 text-xs">{timeAgo(visitor.lastSeen)}</span>
+                        <svg
+                          width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"
+                          strokeLinecap="round" strokeLinejoin="round"
+                          className={`text-neutral-600 transition-transform ${isOpen ? "rotate-180" : ""}`}
+                        >
+                          <polyline points="6 9 12 15 18 9" />
+                        </svg>
+                      </div>
+                    </button>
 
-                            <div className="space-y-3">
-                              {session.pages.map((p, i) => (
-                                <div key={i} className="relative flex items-start gap-3">
-                                  <div className="absolute -left-[11px] top-[5px] w-2 h-2 rounded-full bg-violet-500/60 border border-violet-500 flex-shrink-0" />
-                                  <div className="flex-1 min-w-0">
-                                    <span className="text-neutral-200 text-xs font-mono">{p.page}</span>
+                    {isOpen && (
+                      <div className="border-t border-neutral-800 px-4 py-4 space-y-5">
+                        {visitor.sessions.map((session, si) => (
+                          <div key={session.sessionId}>
+                            {visitor.sessions.length > 1 && (
+                              <p className="text-neutral-600 text-[10px] uppercase tracking-wider mb-2">
+                                Vizita {si + 1} · {formatTime(session.firstSeen)}
+                                {session.pages.length > 1 && ` · ${formatDuration(session.firstSeen, session.lastSeen)}`}
+                              </p>
+                            )}
+                            <div className="relative pl-4">
+                              <div className="absolute left-[5px] top-2 bottom-2 w-px bg-neutral-800" />
+                              <div className="space-y-3">
+                                {session.pages.map((p, i) => (
+                                  <div key={i} className="relative flex items-start gap-3">
+                                    <div className="absolute -left-[11px] top-[5px] w-2 h-2 rounded-full bg-violet-500/60 border border-violet-500 flex-shrink-0" />
+                                    <div className="flex-1 min-w-0">
+                                      <span className="text-neutral-200 text-xs font-mono">{p.page}</span>
+                                    </div>
+                                    <span className="text-neutral-600 text-xs flex-shrink-0">{formatTime(p.timestamp)}</span>
                                   </div>
-                                  <span className="text-neutral-600 text-xs flex-shrink-0">{formatTime(p.timestamp)}</span>
-                                </div>
-                              ))}
+                                ))}
+                              </div>
                             </div>
                           </div>
-                        </div>
-                      ))}
-
-                      {/* Footer info */}
-                      {visitor.org && (
-                        <p className="text-neutral-700 text-xs pt-2 border-t border-neutral-800/60">
-                          {visitor.org}
-                        </p>
-                      )}
-                    </div>
-                  )}
-                </div>
-              );
-            })}
-          </div>
-        )}
+                        ))}
+                        {visitor.org && (
+                          <p className="text-neutral-700 text-xs pt-2 border-t border-neutral-800/60">
+                            {visitor.org}
+                          </p>
+                        )}
+                      </div>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/src/client/features/admin/components/Contracts/ContractActionMenu.tsx
+++ b/src/client/features/admin/components/Contracts/ContractActionMenu.tsx
@@ -14,6 +14,7 @@ interface Props {
   cancelling: string | null;
   deleting: string | null;
   resending: string | null;
+  reminding: string | null;
   onEdit: () => void;
   onSign: () => void;
   onPreview: () => void;
@@ -24,11 +25,12 @@ interface Props {
   onDelete: () => void;
   onResetSignature: () => void;
   onResend: () => void;
+  onReminder: () => void;
 }
 
 const ContractActionMenu: React.FC<Props> = ({
-  contract, canCreateEvent, isSigned, sending, cancelling, deleting, resending,
-  onEdit, onSign, onPreview, onCreateEvent, onSend, onCopyLink, onCancel, onDelete, onResetSignature, onResend,
+  contract, canCreateEvent, isSigned, sending, cancelling, deleting, resending, reminding,
+  onEdit, onSign, onPreview, onCreateEvent, onSend, onCopyLink, onCancel, onDelete, onResetSignature, onResend, onReminder,
 }) => {
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
@@ -92,6 +94,14 @@ const ContractActionMenu: React.FC<Props> = ({
               onClick={onSend}
               color="text-emerald-400"
               loading={sending === contract.id}
+            />
+          )}
+          {contract.status === "sent" && (
+            <Item
+              label="📩  Email re-amintire"
+              onClick={onReminder}
+              color="text-sky-400"
+              loading={reminding === contract.id}
             />
           )}
           <Item label="🔗  Copiază link" onClick={onCopyLink} />

--- a/src/client/features/admin/components/Contracts/ContractListPage.tsx
+++ b/src/client/features/admin/components/Contracts/ContractListPage.tsx
@@ -39,6 +39,7 @@ const ContractListPage: React.FC = () => {
   const [cancelling, setCancelling] = useState<string | null>(null);
   const [deleting, setDeleting] = useState<string | null>(null);
   const [resending, setResending] = useState<string | null>(null);
+  const [reminding, setReminding] = useState<string | null>(null);
   const [creatingEvent, setCreatingEvent] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
@@ -253,6 +254,24 @@ const ContractListPage: React.FC = () => {
     }
   };
 
+  const handleReminder = async (id: string) => {
+    setReminding(id);
+    setActionError(null);
+    try {
+      const res = await fetch(`/api/contracts/${id}/reminder`, {
+        method: "POST",
+        headers: { Authorization: `Bearer ${auth.accessToken}` },
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error);
+      showToast("Email de re-amintire trimis clientului.");
+    } catch (e: unknown) {
+      setActionError("Eroare la reminder: " + (e instanceof Error ? e.message : "necunoscută"));
+    } finally {
+      setReminding(null);
+    }
+  };
+
   const handleCreateEvent = async (id: string) => {
     setCreatingEvent(id);
     setActionError(null);
@@ -421,6 +440,7 @@ const ContractListPage: React.FC = () => {
                       cancelling={cancelling}
                       deleting={deleting}
                       resending={resending}
+                      reminding={reminding}
                       onEdit={() => navigate(`/admin/contracts/${contract.id}/edit`)}
                       onSign={() => { setSigError(null); setSigningId(contract.id); }}
                       onPreview={() => window.open(`/api/contracts/${contract.id}/preview`, "_blank")}
@@ -435,6 +455,7 @@ const ContractListPage: React.FC = () => {
                       onDelete={() => confirmAction("delete", contract.id, `${contract.eventType} — ${contract.clientEmail}`)}
                       onResetSignature={() => handleResetSignature(contract.id)}
                       onResend={() => handleResend(contract.id)}
+                      onReminder={() => handleReminder(contract.id)}
                     />
                   </div>
                   {creatingEvent === contract.id && (

--- a/src/client/pages/MediaDownload/MediaAlbumPage.tsx
+++ b/src/client/pages/MediaDownload/MediaAlbumPage.tsx
@@ -172,13 +172,18 @@ const mediaKeyFromUrl = (src: string) => {
   return dotIndex > 0 ? fileName.slice(0, dotIndex) : fileName;
 };
 
-const getSwissUrl = async (slug: string) => {
+type DeliveryAddressData = {
+  swissLink?: string;
+  deliveryAddress?: { fullName?: string };
+};
+
+const getDeliveryData = async (slug: string): Promise<DeliveryAddressData> => {
   const response = await fetch(`/api/album/${slug}/delivery-address`);
   if (response.ok) {
-    const json = await response.json();
-    return json.data.swissLink;
+    const json = await response.json() as { data?: DeliveryAddressData };
+    return json.data ?? {};
   }
-  return "";
+  return {};
 };
 
 // ── MOBILE COLUMNS TOGGLE ────────────────────────────────────────────────────
@@ -219,6 +224,103 @@ function MobileColumnsToggle({
 
 // ── COMPONENT ────────────────────────────────────────────────────────────────
 
+const PROMO_PHONE = "0745469907";
+const PROMO_PHONE_DISPLAY = "0745 469 907";
+
+function PromoPhoneReveal() {
+  const [open, setOpen] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  function copyPhone() {
+    navigator.clipboard.writeText(PROMO_PHONE).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    });
+  }
+
+  const actionBtn: React.CSSProperties = {
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: "8px",
+    padding: "14px 16px",
+    borderRadius: "8px",
+    fontSize: "15px",
+    fontWeight: 600,
+    textDecoration: "none",
+    cursor: "pointer",
+    border: "none",
+    width: "100%",
+    boxSizing: "border-box",
+  };
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: "12px", width: "100%", maxWidth: "340px", margin: "0 auto" }}>
+      <button
+        onClick={() => setOpen((v) => !v)}
+        style={{
+          ...actionBtn,
+          background: "#1a0f00",
+          color: "#c9a96e",
+          fontSize: "16px",
+          padding: "16px",
+          borderRadius: "8px",
+        }}
+      >
+        📞 Arată număr telefon
+      </button>
+
+      <a
+        href="https://instagram.com/ancavisuals"
+        target="_blank"
+        rel="noopener noreferrer"
+        style={{ ...actionBtn, border: "2px solid #1a0f00", color: "#1a0f00", background: "transparent", fontSize: "15px" }}
+      >
+        Instagram
+      </a>
+
+      {open && (
+        <div style={{
+          background: "#1a0f00",
+          borderRadius: "12px",
+          padding: "20px 16px",
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          gap: "12px",
+          width: "100%",
+        }}>
+          <p style={{ color: "#c9a96e", fontSize: "26px", fontWeight: 700, margin: 0, letterSpacing: "3px" }}>
+            {PROMO_PHONE_DISPLAY}
+          </p>
+          <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "8px", width: "100%" }}>
+            <button
+              onClick={copyPhone}
+              style={{ ...actionBtn, background: copied ? "#2d5a27" : "#2a2010", color: copied ? "#86efac" : "#c9a96e" }}
+            >
+              {copied ? "✓ Copiat!" : "📋 Copiază"}
+            </button>
+            <a href={`tel:${PROMO_PHONE}`} style={{ ...actionBtn, background: "#1a4a1a", color: "#86efac" }}>
+              📞 Apelează
+            </a>
+            <a href={`sms:${PROMO_PHONE}`} style={{ ...actionBtn, background: "#1a2a4a", color: "#93c5fd" }}>
+              💬 SMS
+            </a>
+            <a
+              href={`https://wa.me/40${PROMO_PHONE.slice(1)}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              style={{ ...actionBtn, background: "#0d2e1a", color: "#4ade80" }}
+            >
+              WhatsApp
+            </a>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
 export default function MediaAlbumPage() {
   const { slug } = useParams<{ slug: string }>();
   const [searchParams, setSearchParams] = useSearchParams();
@@ -243,6 +345,7 @@ export default function MediaAlbumPage() {
 
   const [isMobile, setIsMobile] = useState(false);
   const [swissLink, setSwissLink] = useState<string | null>(null);
+  const [hasDeliveryAddress, setHasDeliveryAddress] = useState(false);
   const [isFormOpen, setIsFormOpen] = useState(false);
   const [showDeliveryModal, setShowDeliveryModal] = useState(false);
   const [showUrlModal, setShowUrlModal] = useState(false);
@@ -285,6 +388,7 @@ export default function MediaAlbumPage() {
   const [showSaveWarning, setShowSaveWarning] = useState(false);
   const saveWarningTimerRef = useRef<number | null>(null);
   const [showOnboarding, setShowOnboarding] = useState(false);
+  const [tutorialPrintPhotos, setTutorialPrintPhotos] = useState<string[]>([]);
 
   const photosTopRef = useRef<HTMLDivElement | null>(null);
   const shareBoxRef = useRef<HTMLDivElement | null>(null);
@@ -422,11 +526,14 @@ export default function MediaAlbumPage() {
     let cancelled = false;
     (async () => {
       try {
-        const url = await getSwissUrl(slug);
-        if (!cancelled) setSwissLink(url || null);
+        const data = await getDeliveryData(slug);
+        if (!cancelled) {
+          setSwissLink(data.swissLink || null);
+          setHasDeliveryAddress(!!data.deliveryAddress?.fullName);
+        }
       } catch (error) {
-        console.error("Failed to load swiss link", error);
-        if (!cancelled) setSwissLink(null);
+        console.error("Failed to load delivery data", error);
+        if (!cancelled) { setSwissLink(null); setHasDeliveryAddress(false); }
       }
     })();
     return () => { cancelled = true; };
@@ -963,11 +1070,25 @@ export default function MediaAlbumPage() {
             slug={slug}
             retention={album?.retention ?? null}
             isAdmin={isAdmin || auth.authorise}
-            onAccepted={() => setConsentGiven(true)}
+            onAccepted={() => {
+              setConsentGiven(true);
+              if (!isAdmin && !auth.authorise && !localStorage.getItem('av:onboarding:done')) {
+                setTimeout(() => setShowOnboarding(true), 500);
+              }
+            }}
           />
         )}
 
-        <OnboardingWizard forceShow={showOnboarding} onClose={() => setShowOnboarding(false)} />
+        <OnboardingWizard
+          forceShow={showOnboarding}
+          onStart={() => {
+            if (album?.photos?.length) {
+              const shuffled = [...album.photos].sort(() => Math.random() - 0.5);
+              setTutorialPrintPhotos(shuffled.slice(0, 6));
+            }
+          }}
+          onClose={() => { setShowOnboarding(false); setTutorialPrintPhotos([]); }}
+        />
 
 
         {lightboxIndex !== null && lightboxPhotos.length > 0 && album?.photos && (
@@ -1018,7 +1139,7 @@ export default function MediaAlbumPage() {
             <button
               type="button"
               onClick={() => { localStorage.removeItem('av:onboarding:done'); setShowOnboarding(true); }}
-              style={{ padding: "5px 14px", background: "transparent", border: "1px solid #333", borderRadius: "999px", color: "#666", fontSize: "12px", cursor: "pointer", letterSpacing: "0.05em" }}
+              style={{ padding: "5px 14px", background: "#fef08a", border: "1px solid #ca8a04", borderRadius: "999px", color: "#713f12", fontSize: "12px", cursor: "pointer", letterSpacing: "0.05em", fontWeight: 600 }}
             >
               ? AJUTOR
             </button>
@@ -1070,9 +1191,11 @@ export default function MediaAlbumPage() {
             <button className={styles.fillAction} onClick={() => setIsFormOpen(true)}>
               Completează adresa de livrare
             </button>
-            <button className={styles.viewAction} onClick={() => setShowDeliveryModal(true)}>
-              Vezi adresa de livrare
-            </button>
+            {hasDeliveryAddress && (
+              <button className={styles.viewAction} onClick={() => setShowDeliveryModal(true)}>
+                Vezi adresa de livrare
+              </button>
+            )}
           </div>
         )}
 
@@ -1128,29 +1251,29 @@ export default function MediaAlbumPage() {
         )}
 
         {mode === "none" && subscribeStatus !== "success" && (
-          <div style={{ margin: "0 0 16px", padding: "12px 16px", background: "#0a0a0a", border: "1px solid #2a2a2a", borderRadius: "8px", display: "flex", alignItems: "center", justifyContent: "space-between", gap: "12px", flexWrap: "wrap" }}>
-            <p style={{ color: "#888", fontSize: "13px", margin: 0, whiteSpace: "nowrap" }}>
+          <div data-onboarding="subscribe" style={{ margin: "0 0 16px", padding: "12px 16px", background: "#0a0a0a", border: "1px solid #2a2a2a", borderRadius: "8px", display: "flex", flexDirection: "column", gap: "10px" }}>
+            <p style={{ color: "#888", fontSize: "13px", margin: 0 }}>
               🔔 Notifică-mă când fotograful adaugă poze noi
             </p>
-            <div style={{ display: "flex", gap: "8px", flex: 1, minWidth: "220px" }}>
+            <div style={{ display: "flex", gap: "8px" }}>
               <input
                 type="email"
                 value={subscribeEmail}
                 onChange={(event) => setSubscribeEmail(event.target.value)}
                 onKeyDown={(event) => { if (event.key === "Enter") handleSubscribe(); }}
                 placeholder="adresa@email.com"
-                style={{ flex: 1, padding: "6px 12px", background: "#111", border: "1px solid #333", borderRadius: "6px", color: "#ccc", fontSize: "13px", outline: "none" }}
+                style={{ flex: 1, minWidth: 0, padding: "8px 12px", background: "#111", border: "1px solid #333", borderRadius: "6px", color: "#ccc", fontSize: "13px", outline: "none" }}
               />
               <button
                 onClick={handleSubscribe}
                 disabled={subscribeStatus === "loading" || !subscribeEmail.trim()}
-                style={{ padding: "6px 14px", background: subscribeEmail.trim() ? "#fff" : "#222", color: subscribeEmail.trim() ? "#000" : "#555", border: "none", borderRadius: "6px", fontSize: "13px", fontWeight: 600, cursor: subscribeEmail.trim() ? "pointer" : "not-allowed", whiteSpace: "nowrap" }}
+                style={{ padding: "8px 14px", background: subscribeEmail.trim() ? "#fff" : "#222", color: subscribeEmail.trim() ? "#000" : "#555", border: "none", borderRadius: "6px", fontSize: "13px", fontWeight: 600, cursor: subscribeEmail.trim() ? "pointer" : "not-allowed", whiteSpace: "nowrap", flexShrink: 0 }}
               >
                 {subscribeStatus === "loading" ? "..." : "Abonează-te"}
               </button>
             </div>
             {subscribeStatus === "error" && (
-              <p style={{ color: "#f87171", fontSize: "12px", margin: 0, width: "100%" }}>A apărut o eroare. Încearcă din nou.</p>
+              <p style={{ color: "#f87171", fontSize: "12px", margin: 0 }}>A apărut o eroare. Încearcă din nou.</p>
             )}
           </div>
         )}
@@ -1480,7 +1603,7 @@ export default function MediaAlbumPage() {
         )}
 
         {!isModerationMode && <div className={mode !== "none" ? styles.dimmedArea : undefined} onPointerDown={onDimmedTap}>
-          <div className={styles.sectionRow}>
+          <div className={styles.sectionRow} data-onboarding="print-zone">
             <h2 className={styles.sectionTitle}>Poze de imprimat{printCount ? ` (${printCount})` : ""}</h2>
             <div className={styles.rowActions}>
               {totalPhotos > 0 && (
@@ -1515,6 +1638,20 @@ export default function MediaAlbumPage() {
                 ))}
               </div>
               <MobileColumnsToggle mobileColumns={mobileColumns} onMobileColumnsChange={setMobileColumns} />
+            </>
+          ) : tutorialPrintPhotos.length > 0 ? (
+            <>
+              <div style={{ margin: "0 0 10px", padding: "8px 14px", background: "#1a1000", border: "1px solid #ca8a04", borderRadius: "8px", display: "flex", alignItems: "center", gap: "8px" }}>
+                <span style={{ fontSize: "13px" }}>🎓</span>
+                <p style={{ color: "#fbbf24", fontSize: "12px", margin: 0 }}>Exemplu tutorial — pozele tale selectate vor apărea aici</p>
+              </div>
+              <div className={styles.printPhotosGrid} data-columns={mobileColumns}>
+                {tutorialPrintPhotos.map((src) => (
+                  <div key={src} className={styles.printPhotoWrapper} style={{ opacity: 0.6 }}>
+                    <img src={src} alt="Exemplu poză imprimare" className={styles.printPhotoImg} loading="lazy" />
+                  </div>
+                ))}
+              </div>
             </>
           ) : (
             <p className={styles.emptyPrint}>Nu ai selectat încă poze pentru imprimat.</p>
@@ -1707,6 +1844,22 @@ export default function MediaAlbumPage() {
 
           <MediaRetentionReminder slug={slug || ""} retention={album?.retention ?? null} />
         </div>}
+      </div>
+    </div>
+
+    {/* Promo banner — visible to all album visitors */}
+    <div style={{ background: "#c9a96e", padding: "48px 24px 56px" }}>
+      <div style={{ maxWidth: "640px", margin: "0 auto", textAlign: "center" }}>
+        <p style={{ color: "#7a5c1e", fontSize: "10px", letterSpacing: "4px", textTransform: "uppercase", margin: "0 0 16px", fontWeight: 600 }}>
+          Anca Visuals
+        </p>
+        <h2 style={{ color: "#1a0f00", fontSize: "24px", fontWeight: 600, margin: "0 0 10px", lineHeight: 1.35, letterSpacing: "0.3px" }}>
+          Fotografie & Videografie pentru momentele tale
+        </h2>
+        <p style={{ color: "#5a3d10", fontSize: "14px", margin: "0 0 30px", lineHeight: 1.6 }}>
+          Nuntă · Botez · Majorat · Fotocabină · Videobooth 360°
+        </p>
+        <PromoPhoneReveal />
       </div>
     </div>
 

--- a/src/client/pages/MediaDownload/OnboardingWizard.module.scss
+++ b/src/client/pages/MediaDownload/OnboardingWizard.module.scss
@@ -18,9 +18,34 @@ $arrow-size: 8px;
 .backdrop {
   position: absolute;
   inset: 0;
-  background-color: rgba(0, 0, 0, 0.6);
+  background-color: transparent;
   pointer-events: all;
   cursor: pointer;
+}
+
+.skipTopBtn {
+  position: fixed;
+  top: 16px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 10;
+  pointer-events: all;
+  background: rgba(30, 30, 30, 0.92);
+  border: 1px solid #444;
+  color: #ccc;
+  font-size: 13px;
+  font-family: 'DM Sans', sans-serif;
+  padding: 8px 18px;
+  border-radius: 999px;
+  cursor: pointer;
+  white-space: nowrap;
+  backdrop-filter: blur(4px);
+  transition: background $transition, color $transition;
+
+  &:hover {
+    background: rgba(50, 50, 50, 0.95);
+    color: #fff;
+  }
 }
 
 .highlight {

--- a/src/client/pages/MediaDownload/Onboardingwizard.tsx
+++ b/src/client/pages/MediaDownload/Onboardingwizard.tsx
@@ -10,28 +10,52 @@ type Step = {
 
 const STEPS: Step[] = [
   {
-    targetSelector: '[data-onboarding="pager"]',
-    title: '📄 Pagina următoare',
-    description: 'Pozele sunt împărțite pe pagini. Apasă pe săgeata dreaptă sau pe numărul paginii pentru a merge mai departe.',
+    targetSelector: '[data-onboarding="photo"]',
+    title: '👆 Apasă pe orice poză',
+    description: 'Apasă pe orice poză ca să o vezi mărită, la rezoluție completă. Poți naviga între poze cu săgețile din lateral sau cu swipe stânga/dreapta pe telefon.',
     position: 'bottom',
   },
   {
-    targetSelector: '[data-onboarding="photo"]',
-    title: '👆 Apasă pe o poză',
-    description: 'Apasă pe orice poză ca să o vezi mărită. Poți naviga între ele cu săgețile sau swipe stânga/dreapta.',
+    targetSelector: '[data-onboarding="pager-prev"]',
+    title: '◀ Pagina anterioară',
+    description: 'Apasă pe săgeata stângă „‹ Anterior" pentru a te întoarce la pagina precedentă de poze.',
+    position: 'bottom',
+  },
+  {
+    targetSelector: '[data-onboarding="pager-input"]',
+    title: '📄 Sari direct la o pagină',
+    description: 'Scrie numărul paginii dorite în căsuța din mijloc și apasă Enter. Pozele sunt împărțite pe mai multe pagini — poți sări direct la orice pagină.',
+    position: 'bottom',
+  },
+  {
+    targetSelector: '[data-onboarding="pager-next"]',
+    title: '▶ Pagina următoare',
+    description: 'Apasă pe săgeata dreaptă „Următorul ›" pentru a trece la pagina următoare de poze.',
+    position: 'bottom',
+  },
+  {
+    targetSelector: '[data-onboarding="subscribe"]',
+    title: '🔔 Primești notificare când vin poze noi',
+    description: 'Introdu adresa ta de email și apasă „Abonează-te". Vei primi automat un email imediat ce fotograful adaugă poze noi în acest album — fără să trebuiască să intri zilnic să verifici.',
+    position: 'bottom',
+  },
+  {
+    targetSelector: '[data-onboarding="download-btn"]',
+    title: '⬇️ Descarcă toate pozele',
+    description: 'Apasă acest buton pentru a descărca toate pozele din album ca arhivă ZIP, la calitate completă, exact cum au ieșit din aparat. Descărcarea poate dura câteva minute în funcție de dimensiunea albumului.',
     position: 'bottom',
   },
   {
     targetSelector: '[data-onboarding="print-btn"]',
     title: '🖨️ Selectează pozele pentru imprimare',
-    description: 'Apasă acest buton pentru a intra în modul de selectare. Bifează pozele pe care vrei să le imprimi, apoi salvează selecția.',
+    description: 'Vrei să imprimi unele poze? Apasă acest buton pentru a intra în modul de selectare. Bifează pozele dorite, salvează selecția — fotograful va vedea exact ce ai ales și va pregăti comanda de imprimare.',
     position: 'top',
   },
   {
-    targetSelector: '[data-onboarding="download-btn"]',
-    title: '⬇️ Descarcă toate pozele',
-    description: 'Apasă acest buton pentru a descărca toate pozele tale ca arhivă ZIP, la calitate completă.',
-    position: 'bottom',
+    targetSelector: '[data-onboarding="print-zone"]',
+    title: '📋 Zona pozelor selectate',
+    description: 'Aici vor apărea pozele pe care le-ai selectat pentru imprimare. Poți vedea și elimina orice poză din selecție direct din această zonă, înainte ca fotograful să pregătească comanda.',
+    position: 'top',
   },
 ];
 
@@ -48,9 +72,10 @@ const TOOLTIP_OFFSET = 16;
 type Props = {
   forceShow?: boolean;
   onClose?: () => void;
+  onStart?: () => void;
 };
 
-export default function OnboardingWizard({ forceShow, onClose }: Props) {
+export default function OnboardingWizard({ forceShow, onClose, onStart }: Props) {
   const [currentStep, setCurrentStep] = useState(0);
   const [visible, setVisible] = useState(false);
   const [tooltipPosition, setTooltipPosition] = useState<TooltipPosition | null>(null);
@@ -125,16 +150,9 @@ export default function OnboardingWizard({ forceShow, onClose }: Props) {
 
   const startWizard = useCallback(() => {
     setVisible(true);
+    onStart?.();
     goToStep(0);
-  }, [goToStep]);
-
-  useEffect(() => {
-    const alreadySeen = localStorage.getItem(STORAGE_KEY);
-    if (alreadySeen) return;
-
-    const timer = setTimeout(startWizard, 800);
-    return () => clearTimeout(timer);
-  }, [startWizard]);
+  }, [goToStep, onStart]);
 
   useEffect(() => {
     if (!forceShow) return;
@@ -169,6 +187,10 @@ export default function OnboardingWizard({ forceShow, onClose }: Props) {
   return (
     <div className={styles.root} ref={overlayRef}>
       <div className={styles.backdrop} onClick={handleSkip} />
+
+      <button className={styles.skipTopBtn} onClick={handleSkip}>
+        Sari peste tutorial ✕
+      </button>
 
       <div
         className={styles.highlight}

--- a/src/client/pages/MediaDownload/PhotoLightbox.module.scss
+++ b/src/client/pages/MediaDownload/PhotoLightbox.module.scss
@@ -156,6 +156,23 @@ $transition: 0.2s ease;
     background-color: #236640;
     border-color: #236640;
   }
+
+  @media (max-width: 640px) {
+    padding: 10px;
+    border-radius: 50%;
+    width: 40px;
+    height: 40px;
+    gap: 0;
+
+    span {
+      display: none;
+    }
+
+    svg {
+      width: 18px;
+      height: 18px;
+    }
+  }
 }
 
 .printBtnActive {

--- a/src/client/pages/MediaDownload/PhotoLightbox.tsx
+++ b/src/client/pages/MediaDownload/PhotoLightbox.tsx
@@ -158,7 +158,7 @@ export default function PhotoLightbox({
               <path d="M6 18H4a2 2 0 0 1-2-2v-5a2 2 0 0 1 2-2h16a2 2 0 0 1 2 2v5a2 2 0 0 1-2 2h-2" />
               <rect x="6" y="14" width="12" height="8" />
             </svg>
-            {isInPrint ? 'Elimină din imprimare' : '+ Adaugă la imprimare'}
+            <span>{isInPrint ? 'Elimină din imprimare' : '+ Adaugă la imprimare'}</span>
           </button>
         )}
       </div>

--- a/src/client/pages/Portfolio/AlbumPager.tsx
+++ b/src/client/pages/Portfolio/AlbumPager.tsx
@@ -17,6 +17,7 @@ type Props = {
   onToggleSelectPage: () => void;
   mobileColumns?: 1 | 2;
   onMobileColumnsChange?: (columns: 1 | 2) => void;
+  "data-onboarding"?: string;
 };
 
 export default function AlbumPager({
@@ -35,6 +36,7 @@ export default function AlbumPager({
   onToggleSelectPage,
   mobileColumns,
   onMobileColumnsChange,
+  "data-onboarding": dataOnboarding,
 }: Props) {
   const [value, setValue] = useState(String(currentPage));
 
@@ -62,21 +64,21 @@ export default function AlbumPager({
   };
 
   return (
-    <div className={styles.bar}>
+    <div className={styles.bar} data-onboarding={dataOnboarding}>
       <div className={styles.row}>
         <div className={styles.left}>
-          <button className={styles.btn} type="button" onClick={onFirst} disabled={disabled || currentPage <= 1}>
+          <button className={styles.btn} type="button" onClick={onFirst} disabled={disabled || currentPage <= 1} data-onboarding="pager-first">
             <span className={styles.icon} aria-hidden="true">«</span>
             <span className={styles.label}>Primul</span>
           </button>
 
-          <button className={styles.btn} type="button" onClick={onPrev} disabled={disabled || currentPage <= 1}>
+          <button className={styles.btn} type="button" onClick={onPrev} disabled={disabled || currentPage <= 1} data-onboarding="pager-prev">
             <span className={styles.icon} aria-hidden="true">‹</span>
             <span className={styles.label}>Anterior</span>
           </button>
         </div>
 
-        <div className={styles.pg}>
+        <div className={styles.pg} data-onboarding="pager-input">
           <span className={styles.pgLabel}>Pagina</span>
           <input
             className={styles.pgInput}
@@ -95,12 +97,12 @@ export default function AlbumPager({
         </div>
 
         <div className={styles.right}>
-          <button className={styles.btn} type="button" onClick={onNext} disabled={disabled || currentPage >= totalPages}>
+          <button className={styles.btn} type="button" onClick={onNext} disabled={disabled || currentPage >= totalPages} data-onboarding="pager-next">
             <span className={styles.label}>Următorul</span>
             <span className={styles.icon} aria-hidden="true">›</span>
           </button>
 
-          <button className={styles.btn} type="button" onClick={onLast} disabled={disabled || currentPage >= totalPages}>
+          <button className={styles.btn} type="button" onClick={onLast} disabled={disabled || currentPage >= totalPages} data-onboarding="pager-last">
             <span className={styles.label}>Ultimul</span>
             <span className={styles.icon} aria-hidden="true">»</span>
           </button>

--- a/src/server/notifications/templates/contractEmail.ts
+++ b/src/server/notifications/templates/contractEmail.ts
@@ -1,6 +1,23 @@
 import { mailer } from "../mailer";
 import { adminUser, emailAuth } from "../../constants/credentials";
 
+const EMAIL_HEADER = `
+  <div style="text-align: center; margin-bottom: 24px;">
+    <h2 style="color: #c9a96e; font-weight: 300; letter-spacing: 3px; font-size: 20px; margin: 0;">ANCA VISUALS</h2>
+    <p style="color: #999; font-size: 11px; letter-spacing: 1px; margin: 4px 0 0; text-transform: uppercase;">Fotografie & Videografie</p>
+  </div>
+  <hr style="border: none; border-top: 1px solid #c9a96e; margin: 0 0 28px;" />`;
+
+const EMAIL_FOOTER = `
+  <hr style="border: none; border-top: 1px solid #eee; margin: 28px 0 16px;" />
+  <p style="color: #bbb; font-size: 10px; text-align: center; margin: 0;">
+    Anca Visuals &nbsp;•&nbsp; ancadaniel1994@gmail.com
+  </p>`;
+
+function emailWrap(body: string): string {
+  return `<div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto; padding: 40px 20px; background: #fff;">${EMAIL_HEADER}${body}${EMAIL_FOOTER}</div>`;
+}
+
 interface ContractLinkEmailOptions {
   to: string;
   token: string;
@@ -14,50 +31,25 @@ export async function sendContractLinkEmail(options: ContractLinkEmailOptions): 
   const link = `${baseUrl}/contract/${token}`;
   const formattedDate = formatRoDate(eventDate);
 
-  const clientHtml = `
-      <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto; padding: 40px 20px; background: #fff;">
-        <div style="text-align: center; margin-bottom: 24px;">
-          <h2 style="color: #c9a96e; font-weight: 300; letter-spacing: 3px; font-size: 20px; margin: 0;">ANCA VISUALS</h2>
-          <p style="color: #999; font-size: 11px; letter-spacing: 1px; margin: 4px 0 0; text-transform: uppercase;">Fotografie & Videografie</p>
-        </div>
-        <hr style="border: none; border-top: 1px solid #c9a96e; margin: 0 0 28px;" />
-
-        <p style="color: #333; margin-bottom: 12px;">Bună ziua,</p>
-        <p style="color: #333; margin-bottom: 12px;">
-          Contractul de prestări servicii foto/video pentru evenimentul
-          <strong>${eventType}</strong> din data de <strong>${formattedDate}</strong>
-          este gata pentru semnare.
-        </p>
-        <p style="color: #555; margin-bottom: 28px;">
-          Vă rugăm să accesați link-ul de mai jos, să citiți cu atenție contractul,
-          să completați datele personale și să semnați electronic.
-        </p>
-
-        <div style="text-align: center; margin-bottom: 28px;">
-          <a href="${link}" style="
-            display: inline-block;
-            background-color: #c9a96e;
-            color: #fff;
-            padding: 14px 36px;
-            text-decoration: none;
-            border-radius: 4px;
-            font-size: 15px;
-            font-weight: 600;
-            letter-spacing: 1px;
-          ">Semnează Contractul</a>
-        </div>
-
-        <p style="color: #aaa; font-size: 11px; text-align: center;">
-          Sau accesați direct:<br/>
-          <a href="${link}" style="color: #c9a96e; word-break: break-all;">${link}</a>
-        </p>
-
-        <hr style="border: none; border-top: 1px solid #eee; margin: 28px 0 16px;" />
-        <p style="color: #bbb; font-size: 10px; text-align: center; margin: 0;">
-          Anca Visuals &nbsp;•&nbsp; ancadaniel1994@gmail.com
-        </p>
-      </div>
-    `;
+  const clientHtml = emailWrap(`
+    <p style="color: #333; margin-bottom: 12px;">Bună ziua,</p>
+    <p style="color: #333; margin-bottom: 12px;">
+      Contractul de prestări servicii foto/video pentru evenimentul
+      <strong>${eventType}</strong> din data de <strong>${formattedDate}</strong>
+      este gata pentru semnare.
+    </p>
+    <p style="color: #555; margin-bottom: 28px;">
+      Vă rugăm să accesați link-ul de mai jos, să citiți cu atenție contractul,
+      să completați datele personale și să semnați electronic.
+    </p>
+    <div style="text-align: center; margin-bottom: 28px;">
+      <a href="${link}" style="display:inline-block;background-color:#c9a96e;color:#fff;padding:14px 36px;text-decoration:none;border-radius:4px;font-size:15px;font-weight:600;letter-spacing:1px;">Semnează Contractul</a>
+    </div>
+    <p style="color: #aaa; font-size: 11px; text-align: center;">
+      Sau accesați direct:<br/>
+      <a href="${link}" style="color: #c9a96e; word-break: break-all;">${link}</a>
+    </p>
+  `);
 
   await mailer.sendMail({
     from: emailAuth.email,
@@ -92,40 +84,16 @@ export async function sendSignedContractEmail(options: SignedContractEmailOption
     ? "Puteți descărca contractul semnat accesând butonul de mai jos. Link-ul este permanent și poate fi accesat oricând."
     : "Contractul a fost semnat. PDF-ul se generează — îl puteți accesa în curând accesând link-ul de mai jos.";
 
-  const html = `
-    <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto; padding: 40px 20px; background: #fff;">
-      <div style="text-align: center; margin-bottom: 24px;">
-        <h2 style="color: #c9a96e; font-weight: 300; letter-spacing: 3px; font-size: 20px; margin: 0;">ANCA VISUALS</h2>
-        <p style="color: #999; font-size: 11px; letter-spacing: 1px; margin: 4px 0 0; text-transform: uppercase;">Fotografie & Videografie</p>
-      </div>
-      <hr style="border: none; border-top: 1px solid #c9a96e; margin: 0 0 28px;" />
-
-      <p style="color: #333; margin-bottom: 12px;">
-        Contractul pentru evenimentul <strong>${eventType}</strong> din <strong>${formattedDate}</strong>
-        a fost semnat cu succes de <strong>${clientName}</strong>.
-      </p>
-      <p style="color: #555; margin-bottom: 28px;">${bodyText}</p>
-
-      <div style="text-align: center; margin-bottom: 28px;">
-        <a href="${pdfUrl}" style="
-          display: inline-block;
-          background-color: #c9a96e;
-          color: #fff;
-          padding: 14px 36px;
-          text-decoration: none;
-          border-radius: 4px;
-          font-size: 15px;
-          font-weight: 600;
-          letter-spacing: 1px;
-        ">${buttonLabel}</a>
-      </div>
-
-      <hr style="border: none; border-top: 1px solid #eee; margin: 28px 0 16px;" />
-      <p style="color: #bbb; font-size: 10px; text-align: center; margin: 0;">
-        Anca Visuals &nbsp;•&nbsp; ancadaniel1994@gmail.com
-      </p>
+  const html = emailWrap(`
+    <p style="color: #333; margin-bottom: 12px;">
+      Contractul pentru evenimentul <strong>${eventType}</strong> din <strong>${formattedDate}</strong>
+      a fost semnat cu succes de <strong>${clientName}</strong>.
+    </p>
+    <p style="color: #555; margin-bottom: 28px;">${bodyText}</p>
+    <div style="text-align: center; margin-bottom: 28px;">
+      <a href="${pdfUrl}" style="display:inline-block;background-color:#c9a96e;color:#fff;padding:14px 36px;text-decoration:none;border-radius:4px;font-size:15px;font-weight:600;letter-spacing:1px;">${buttonLabel}</a>
     </div>
-  `;
+  `);
 
   await mailer.sendMail({
     from: emailAuth.email,
@@ -173,50 +141,74 @@ export async function sendContractDeletedEmail({ contract }: DeletedContractEmai
       <td style="padding: 6px 12px; color: #1a1a1a; font-size: 12px; font-weight: 600;">${value}</td>
     </tr>`).join("");
 
-  const html = `
-    <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto; padding: 40px 20px; background: #fff;">
-      <div style="text-align: center; margin-bottom: 24px;">
-        <h2 style="color: #c9a96e; font-weight: 300; letter-spacing: 3px; font-size: 20px; margin: 0;">ANCA VISUALS</h2>
-        <p style="color: #999; font-size: 11px; letter-spacing: 1px; margin: 4px 0 0; text-transform: uppercase;">Fotografie & Videografie</p>
-      </div>
-      <hr style="border: none; border-top: 2px solid #ef4444; margin: 0 0 28px;" />
-
-      <p style="color: #ef4444; font-weight: 700; font-size: 15px; margin-bottom: 6px;">⚠ Contract șters definitiv</p>
-      <p style="color: #555; font-size: 13px; margin-bottom: 24px;">
-        Acest email conține detaliile contractului șters, pentru arhivă personală.
-        Dacă ștergerea a fost accidentală, contactează imediat furnizorul de hosting pentru recuperare din backup.
-      </p>
-
-      <table style="width: 100%; border-collapse: collapse; background: #fafafa; border-radius: 8px; overflow: hidden; margin-bottom: 20px;">
-        <tbody>${tableRows}</tbody>
-      </table>
-
-      ${pdfUrl ? `
-      <div style="text-align: center; margin: 24px 0;">
-        <a href="${pdfUrl}" style="
-          display: inline-block; background: #c9a96e; color: #fff;
-          padding: 12px 28px; text-decoration: none; border-radius: 4px;
-          font-size: 13px; font-weight: 600; letter-spacing: 1px;
-        ">Descarcă PDF-ul contractului</a>
-        <p style="color: #aaa; font-size: 11px; margin-top: 8px;">
-          Linkul poate expira. Salvează PDF-ul dacă ai nevoie de el.
-        </p>
-      </div>` : `
-      <p style="color: #aaa; font-size: 12px; text-align: center;">
-        PDF-ul nu era disponibil pentru acest contract.
-      </p>`}
-
-      <hr style="border: none; border-top: 1px solid #eee; margin: 28px 0 16px;" />
-      <p style="color: #bbb; font-size: 10px; text-align: center; margin: 0;">
-        Anca Visuals &nbsp;•&nbsp; ancadaniel1994@gmail.com
-      </p>
-    </div>
-  `;
+  const html = `<div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto; padding: 40px 20px; background: #fff;">${EMAIL_HEADER.replace('border-top: 1px solid #c9a96e', 'border-top: 2px solid #ef4444')}
+    <p style="color: #ef4444; font-weight: 700; font-size: 15px; margin-bottom: 6px;">⚠ Contract șters definitiv</p>
+    <p style="color: #555; font-size: 13px; margin-bottom: 24px;">
+      Acest email conține detaliile contractului șters, pentru arhivă personală.
+      Dacă ștergerea a fost accidentală, contactează imediat furnizorul de hosting pentru recuperare din backup.
+    </p>
+    <table style="width: 100%; border-collapse: collapse; background: #fafafa; border-radius: 8px; overflow: hidden; margin-bottom: 20px;">
+      <tbody>${tableRows}</tbody>
+    </table>
+    ${pdfUrl ? `
+    <div style="text-align: center; margin: 24px 0;">
+      <a href="${pdfUrl}" style="display:inline-block;background:#c9a96e;color:#fff;padding:12px 28px;text-decoration:none;border-radius:4px;font-size:13px;font-weight:600;letter-spacing:1px;">Descarcă PDF-ul contractului</a>
+      <p style="color: #aaa; font-size: 11px; margin-top: 8px;">Linkul poate expira. Salvează PDF-ul dacă ai nevoie de el.</p>
+    </div>` : `<p style="color: #aaa; font-size: 12px; text-align: center;">PDF-ul nu era disponibil pentru acest contract.</p>`}
+    ${EMAIL_FOOTER}
+  </div>`;
 
   await mailer.sendMail({
     from: emailAuth.email,
     to: adminUser.email,
     subject: `[Șters] Contract ${eventType} — ${eventDate} — ${clientEmail}`,
+    html,
+  });
+}
+
+interface ContractReminderEmailOptions {
+  to: string;
+  token: string;
+  eventType: string;
+  eventDate: string;
+  baseUrl: string;
+}
+
+export async function sendContractReminderEmail(options: ContractReminderEmailOptions): Promise<void> {
+  const { to, token, eventType, eventDate, baseUrl } = options;
+  const link = `${baseUrl}/contract/${token}`;
+  const formattedDate = formatRoDate(eventDate);
+
+  const html = emailWrap(`
+    <p style="color: #333; margin-bottom: 12px;">Bună ziua,</p>
+    <p style="color: #333; margin-bottom: 12px;">
+      Vă trimitem un scurt reminder că contractul pentru evenimentul
+      <strong>${eventType}</strong> din data de <strong>${formattedDate}</strong>
+      nu a fost semnat încă.
+    </p>
+    <p style="color: #555; margin-bottom: 28px;">
+      Vă rugăm să accesați link-ul de mai jos pentru a semna contractul. Procesul durează doar câteva minute.
+    </p>
+    <div style="text-align: center; margin-bottom: 28px;">
+      <a href="${link}" style="display:inline-block;background-color:#c9a96e;color:#fff;padding:14px 36px;text-decoration:none;border-radius:4px;font-size:15px;font-weight:600;letter-spacing:1px;">Semnează Contractul</a>
+    </div>
+    <p style="color: #aaa; font-size: 11px; text-align: center;">
+      Sau accesați direct:<br/>
+      <a href="${link}" style="color: #c9a96e; word-break: break-all;">${link}</a>
+    </p>
+  `);
+
+  await mailer.sendMail({
+    from: emailAuth.email,
+    to,
+    subject: `Reminder: Contract nesemnat — ${eventType} ${formattedDate}`,
+    html,
+  });
+
+  await mailer.sendMail({
+    from: emailAuth.email,
+    to: adminUser.email,
+    subject: `[Copie] Reminder trimis — ${eventType} ${formattedDate} — ${to}`,
     html,
   });
 }

--- a/src/server/routes/analytics.routes.ts
+++ b/src/server/routes/analytics.routes.ts
@@ -142,29 +142,45 @@ analyticsAdminRouter.get("/analytics/stats", async (req: Request, res: Response)
     const uniqueVisitors = (snap: FirebaseFirestore.QuerySnapshot): number =>
       new Set(snap.docs.map((d) => d.data().visitorId || d.data().sessionId)).size;
 
-    const [todaySnap, weekSnap, monthSnap, halfYearSnap, yearSnap] = await Promise.all([
+    const [todaySnap, threeDaysSnap, weekSnap, monthSnap, threeMonthsSnap] = await Promise.all([
       db.collection("siteVisits").where("timestamp", ">=", Timestamp.fromDate(todayStart)).get(),
+      db.collection("siteVisits").where("timestamp", ">=", Timestamp.fromDate(daysAgo(3))).get(),
       db.collection("siteVisits").where("timestamp", ">=", Timestamp.fromDate(daysAgo(7))).get(),
       db.collection("siteVisits").where("timestamp", ">=", Timestamp.fromDate(daysAgo(30))).get(),
-      db.collection("siteVisits").where("timestamp", ">=", Timestamp.fromDate(daysAgo(180))).get(),
-      db.collection("siteVisits").where("timestamp", ">=", Timestamp.fromDate(daysAgo(365))).get(),
+      db.collection("siteVisits").where("timestamp", ">=", Timestamp.fromDate(daysAgo(90))).get(),
     ]);
 
     const pageCount: Record<string, number> = {};
+    const referrerCount: Record<string, number> = {};
+    const countryCount: Record<string, number> = {};
+
     monthSnap.docs.forEach((d) => {
-      const page = d.data().page as string;
+      const data = d.data();
+      const page = data.page as string;
       pageCount[page] = (pageCount[page] ?? 0) + 1;
+
+      const ref = data.referrer as string;
+      if (ref && !ref.includes("ancavisuals.ro")) {
+        try {
+          const host = new URL(ref).hostname.replace(/^www\./, "");
+          referrerCount[host] = (referrerCount[host] ?? 0) + 1;
+        } catch { /* invalid URL */ }
+      }
+
+      const country = data.country as string;
+      if (country) countryCount[country] = (countryCount[country] ?? 0) + 1;
     });
+
     const topPages = Object.entries(pageCount)
       .sort(([, a], [, b]) => b - a)
       .slice(0, 10)
       .map(([page, count]) => ({ page, count }));
 
-    const countryCount: Record<string, number> = {};
-    monthSnap.docs.forEach((d) => {
-      const country = d.data().country as string;
-      if (country) countryCount[country] = (countryCount[country] ?? 0) + 1;
-    });
+    const topReferrers = Object.entries(referrerCount)
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, 5)
+      .map(([referrer, count]) => ({ referrer, count }));
+
     const topCountries = Object.entries(countryCount)
       .sort(([, a], [, b]) => b - a)
       .slice(0, 5)
@@ -172,11 +188,12 @@ analyticsAdminRouter.get("/analytics/stats", async (req: Request, res: Response)
 
     res.json({
       today: { visitors: uniqueVisitors(todaySnap) },
+      threeDays: { visitors: uniqueVisitors(threeDaysSnap) },
       week: { visitors: uniqueVisitors(weekSnap) },
       month: { visitors: uniqueVisitors(monthSnap) },
-      halfYear: { visitors: uniqueVisitors(halfYearSnap) },
-      year: { visitors: uniqueVisitors(yearSnap) },
+      threeMonths: { visitors: uniqueVisitors(threeMonthsSnap) },
       topPages,
+      topReferrers,
       topCountries,
     });
   } catch (error) {

--- a/src/server/routes/contracts.routes.ts
+++ b/src/server/routes/contracts.routes.ts
@@ -6,7 +6,7 @@ import { getStorage } from "firebase-admin/storage";
 import { firestore } from "../firestore";
 import { FIREBASE_STORAGE_BUCKET } from "../constants/firebase";
 import { generateContractPDF, buildContractHTML } from "../services/pdf.generator";
-import { sendContractLinkEmail, sendSignedContractEmail, sendContractDeletedEmail } from "../notifications/templates/contractEmail";
+import { sendContractLinkEmail, sendSignedContractEmail, sendContractDeletedEmail, sendContractReminderEmail } from "../notifications/templates/contractEmail";
 import { getClientIp, fetchIpInfo } from "../utils/ipinfo";
 import { requireFirebaseAuth, requireSupremeAdmin } from "../middleware/requireFirebaseAuth";
 import { expandEventDates } from "../utils/expandEventDates";
@@ -14,6 +14,12 @@ import { APP_BASE_URL } from "../constants/domain";
 
 const router = Router();
 const BOOKED_EVENT_STATUSES = new Set(["confirmat", "finalizat"]);
+
+function tsToISO(value: unknown): string | null {
+  if (value instanceof Timestamp) return value.toDate().toISOString();
+  if (typeof value === "string") return value;
+  return null;
+}
 
 type AdminEventType = "Nuntă" | "Botez" | "Logodnă" | "Aniversare" | "Altele";
 
@@ -116,9 +122,9 @@ router.get("/", async (_req: Request, res: Response) => {
       return {
         id: doc.id,
         ...data,
-        createdAt: data.createdAt instanceof Timestamp ? data.createdAt.toDate().toISOString() : data.createdAt,
-        signedAt: data.signedAt instanceof Timestamp ? data.signedAt.toDate().toISOString() : (data.signedAt ?? null),
-        sentAt: data.sentAt instanceof Timestamp ? data.sentAt.toDate().toISOString() : (data.sentAt ?? null),
+        createdAt: tsToISO(data.createdAt),
+        signedAt: tsToISO(data.signedAt),
+        sentAt: tsToISO(data.sentAt),
       };
     });
 
@@ -146,7 +152,7 @@ router.get("/sign/:token/pdf", async (req: Request, res: Response) => {
     const pdfBuffer = await generateContractPDF({
       ...publicData,
       ...bankDetails,
-      createdAt: data.createdAt instanceof Timestamp ? data.createdAt.toDate().toISOString() : data.createdAt,
+      createdAt: tsToISO(data.createdAt),
       ...(req.query.clientName !== undefined ? { clientName: String(req.query.clientName) } : {}),
       ...(req.query.clientAddress !== undefined ? { clientAddress: String(req.query.clientAddress) } : {}),
       ...(req.query.clientPhone !== undefined ? { clientPhone: String(req.query.clientPhone) } : {}),
@@ -176,7 +182,7 @@ router.get("/sign/:token/html", async (req: Request, res: Response) => {
     const html = buildContractHTML({
       ...publicData,
       ...bankDetails,
-      createdAt: data.createdAt instanceof Timestamp ? data.createdAt.toDate().toISOString() : data.createdAt,
+      createdAt: tsToISO(data.createdAt),
       ...(req.query.clientName !== undefined ? { clientName: String(req.query.clientName) } : {}),
       ...(req.query.clientAddress !== undefined ? { clientAddress: String(req.query.clientAddress) } : {}),
       ...(req.query.clientPhone !== undefined ? { clientPhone: String(req.query.clientPhone) } : {}),
@@ -224,7 +230,7 @@ router.get("/sign/:token", async (req: Request, res: Response) => {
       id: doc.id,
       ...publicData,
       ...bankDetails,
-      createdAt: data.createdAt instanceof Timestamp ? data.createdAt.toDate().toISOString() : data.createdAt,
+      createdAt: tsToISO(data.createdAt),
     });
   } catch (error) {
     console.error("[contracts] GET /sign/:token failed:", error);
@@ -413,8 +419,8 @@ router.get("/:id", async (req: Request, res: Response) => {
     res.json({
       id: doc.id,
       ...data,
-      createdAt: data.createdAt instanceof Timestamp ? data.createdAt.toDate().toISOString() : data.createdAt,
-      signedAt: data.signedAt instanceof Timestamp ? data.signedAt.toDate().toISOString() : (data.signedAt ?? null),
+      createdAt: tsToISO(data.createdAt),
+      signedAt: tsToISO(data.signedAt),
     });
   } catch (error) {
     console.error("[contracts] GET /:id failed:", error);
@@ -555,7 +561,7 @@ router.get("/:id/preview", async (req: Request, res: Response) => {
       ...data,
       ...bankDetails,
       id: doc.id,
-      createdAt: data.createdAt instanceof Timestamp ? data.createdAt.toDate().toISOString() : data.createdAt,
+      createdAt: tsToISO(data.createdAt),
     };
     const pdfBuffer = await generateContractPDF(contract as Record<string, unknown>);
     res.setHeader("Content-Type", "application/pdf");
@@ -602,6 +608,33 @@ router.post("/:id/prestator-sign", async (req: Request, res: Response) => {
   } catch (error) {
     console.error("[contracts] POST /:id/prestator-sign failed:", error);
     res.status(500).json({ error: "Eroare server." });
+  }
+});
+
+// POST /api/contracts/:id/reminder — send unsigned-contract reminder to client (admin)
+router.post("/:id/reminder", requireFirebaseAuth, requireSupremeAdmin, async (req: Request, res: Response) => {
+  try {
+    const db = firestore();
+    const doc = await db.collection("contracts").doc(req.params.id).get();
+    if (!doc.exists) return res.status(404).json({ error: "Contract negăsit." });
+
+    const contract = doc.data()!;
+    if (contract.status !== "sent") {
+      return res.status(400).json({ error: "Reminder-ul se poate trimite doar pentru contracte nesemnate (status: trimis)." });
+    }
+
+    await sendContractReminderEmail({
+      to: contract.clientEmail,
+      token: contract.token,
+      eventType: contract.eventType,
+      eventDate: contract.eventDate,
+      baseUrl: APP_BASE_URL,
+    });
+
+    res.json({ ok: true });
+  } catch (error) {
+    console.error("[contracts] POST /:id/reminder failed:", error);
+    res.status(500).json({ error: "Nu s-a putut trimite reminder-ul." });
   }
 });
 

--- a/tests/vitest/client/pages/Contract/ContractListPage.test.tsx
+++ b/tests/vitest/client/pages/Contract/ContractListPage.test.tsx
@@ -10,6 +10,10 @@ import ContractListPage from "src/client/features/admin/components/Contracts/Con
 
 const mockNavigate = vi.fn();
 
+vi.mock("src/client/features/admin/auth/useAuth", () => ({
+  default: () => ({ auth: { accessToken: "test-token" } }),
+}));
+
 vi.mock("react-router-dom", async () => {
   const actual = await vi.importActual<typeof import("react-router-dom")>("react-router-dom");
   return {
@@ -106,6 +110,38 @@ describe("ContractListPage", () => {
       expect(fetchMock.mock.calls[2][0]).toBe("/api/contracts/contract-1/send");
       expect(fetchMock.mock.calls[2][1]).toEqual({ method: "POST" });
       expect(await screen.findByText("Trimis")).toBeInTheDocument();
+    });
+
+    test("resend sends signed contract with Bearer auth header", async () => {
+      const signedContract = {
+        id: "contract-signed",
+        token: "token-signed",
+        status: "signed",
+        eventType: "Nunta",
+        eventDate: "2026-09-12T00:00:00.000Z",
+        clientEmail: "client@example.com",
+        priceTotal: 1200,
+        createdAt: "2026-04-14T10:00:00.000Z",
+      };
+      const fetchMock = vi.fn()
+        .mockResolvedValueOnce({ ok: true, json: async () => ({ contracts: [signedContract] }) })
+        .mockResolvedValueOnce({ ok: true, json: async () => ({ dates: [] }) })
+        .mockResolvedValueOnce({ ok: true, json: async () => ({ ok: true }) });
+      vi.stubGlobal("fetch", fetchMock);
+
+      renderPage();
+
+      fireEvent.click(await screen.findByRole("button", { name: "Acțiuni" }));
+      fireEvent.click(await screen.findByRole("button", { name: /Retrimite contract semnat/ }));
+
+      await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(3));
+
+      expect(fetchMock.mock.calls[2][0]).toBe("/api/contracts/contract-signed/resend");
+      expect(fetchMock.mock.calls[2][1]).toEqual({
+        method: "POST",
+        headers: { Authorization: "Bearer test-token" },
+      });
+      expect(await screen.findByText("Contract retrimis pe email către tine și client.")).toBeInTheDocument();
     });
 
     test("copies the public signing link to clipboard", async () => {

--- a/tests/vitest/client/pages/MediaDownload/AlbumPager.test.tsx
+++ b/tests/vitest/client/pages/MediaDownload/AlbumPager.test.tsx
@@ -1,0 +1,120 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, expect, test, vi, beforeEach } from "vitest";
+import AlbumPager from "src/client/pages/Portfolio/AlbumPager";
+
+function renderPager(overrides: Partial<React.ComponentProps<typeof AlbumPager>> = {}) {
+  return render(
+    <AlbumPager
+      mode="none"
+      currentPage={2}
+      totalPages={5}
+      pageSize={20}
+      totalItems={100}
+      shownCount={20}
+      allOnPageSelected={false}
+      onFirst={vi.fn()}
+      onPrev={vi.fn()}
+      onNext={vi.fn()}
+      onLast={vi.fn()}
+      onGoTo={vi.fn()}
+      onToggleSelectPage={vi.fn()}
+      {...overrides}
+    />,
+  );
+}
+
+describe("AlbumPager", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("renders prev and next buttons", () => {
+    renderPager();
+    expect(screen.getByLabelText("Mergi la pagina")).toBeTruthy();
+    expect(screen.getByText("Anterior")).toBeTruthy();
+    expect(screen.getByText("Următorul")).toBeTruthy();
+  });
+
+  test("calls onNext when next button clicked", () => {
+    const onNext = vi.fn();
+    renderPager({ onNext });
+    fireEvent.click(screen.getByText("Următorul").closest("button")!);
+    expect(onNext).toHaveBeenCalledOnce();
+  });
+
+  test("calls onPrev when prev button clicked", () => {
+    const onPrev = vi.fn();
+    renderPager({ onPrev });
+    fireEvent.click(screen.getByText("Anterior").closest("button")!);
+    expect(onPrev).toHaveBeenCalledOnce();
+  });
+
+  test("prev button disabled on first page", () => {
+    renderPager({ currentPage: 1 });
+    const prevBtn = screen.getByText("Anterior").closest("button")!;
+    expect(prevBtn).toBeDisabled();
+  });
+
+  test("next button disabled on last page", () => {
+    renderPager({ currentPage: 5, totalPages: 5 });
+    const nextBtn = screen.getByText("Următorul").closest("button")!;
+    expect(nextBtn).toBeDisabled();
+  });
+
+  test("data-onboarding prop forwarded to root element", () => {
+    const { container } = renderPager({ "data-onboarding": "pager" });
+    const root = container.firstChild as HTMLElement;
+    expect(root.getAttribute("data-onboarding")).toBe("pager");
+  });
+
+  test("pager-prev attribute on prev button", () => {
+    renderPager();
+    const prevBtn = screen.getByText("Anterior").closest("button")!;
+    expect(prevBtn.getAttribute("data-onboarding")).toBe("pager-prev");
+  });
+
+  test("pager-next attribute on next button", () => {
+    renderPager();
+    const nextBtn = screen.getByText("Următorul").closest("button")!;
+    expect(nextBtn.getAttribute("data-onboarding")).toBe("pager-next");
+  });
+
+  test("pager-first attribute on first button", () => {
+    renderPager();
+    const firstBtn = screen.getByText("Primul").closest("button")!;
+    expect(firstBtn.getAttribute("data-onboarding")).toBe("pager-first");
+  });
+
+  test("pager-last attribute on last button", () => {
+    renderPager();
+    const lastBtn = screen.getByText("Ultimul").closest("button")!;
+    expect(lastBtn.getAttribute("data-onboarding")).toBe("pager-last");
+  });
+
+  test("page input has pager-input data attribute", () => {
+    renderPager();
+    const input = screen.getByLabelText("Mergi la pagina");
+    const wrapper = input.closest("[data-onboarding='pager-input']");
+    expect(wrapper).toBeTruthy();
+  });
+
+  test("calls onGoTo with correct page on Enter", () => {
+    const onGoTo = vi.fn();
+    renderPager({ onGoTo });
+    const input = screen.getByLabelText("Mergi la pagina");
+    fireEvent.change(input, { target: { value: "4" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(onGoTo).toHaveBeenCalledWith(4);
+  });
+
+  test("shows correct range info", () => {
+    renderPager({ currentPage: 2, pageSize: 20, totalItems: 100, shownCount: 20 });
+    expect(screen.getByText("21-40 din 100")).toBeTruthy();
+  });
+
+  test("shows select page button in print mode", () => {
+    renderPager({ mode: "print" });
+    expect(screen.getByText("Selectează pagina")).toBeTruthy();
+  });
+});

--- a/tests/vitest/client/pages/MediaDownload/MediaConsentModal.test.tsx
+++ b/tests/vitest/client/pages/MediaDownload/MediaConsentModal.test.tsx
@@ -1,0 +1,111 @@
+import React from "react";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import { describe, expect, test, vi, beforeEach } from "vitest";
+import MediaConsentModal from "src/client/pages/MediaDownload/MediaConsentModal";
+
+const CONSENT_KEY = "av:consent:test-album";
+
+function renderModal(overrides: Partial<React.ComponentProps<typeof MediaConsentModal>> = {}) {
+  return render(
+    <MediaConsentModal
+      slug="test-album"
+      retention={null}
+      onAccepted={vi.fn()}
+      {...overrides}
+    />,
+  );
+}
+
+describe("MediaConsentModal", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.restoreAllMocks();
+    vi.stubGlobal("fetch", vi.fn(() => Promise.resolve({ ok: true, json: async () => ({}) })));
+  });
+
+  test("shows modal on first visit (no consent in localStorage)", () => {
+    renderModal();
+    expect(screen.getByText("Materialele tale sunt gata")).toBeTruthy();
+  });
+
+  test("does not show modal when consent already given", () => {
+    localStorage.setItem(CONSENT_KEY, "1");
+    const { container } = renderModal();
+    expect(container.firstChild).toBeNull();
+  });
+
+  test("accept button disabled until checkbox checked", () => {
+    renderModal();
+    const btn = screen.getByRole("button", { name: /am înțeles, continuă/i });
+    expect(btn).toBeDisabled();
+  });
+
+  test("accept button enabled after checking checkbox", () => {
+    renderModal();
+    const checkbox = screen.getByRole("checkbox");
+    fireEvent.click(checkbox);
+    const btn = screen.getByRole("button", { name: /am înțeles, continuă/i });
+    expect(btn).not.toBeDisabled();
+  });
+
+  test("calls onAccepted after accepting", async () => {
+    const onAccepted = vi.fn();
+    renderModal({ onAccepted });
+
+    fireEvent.click(screen.getByRole("checkbox"));
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /am înțeles, continuă/i }));
+    });
+
+    expect(onAccepted).toHaveBeenCalledOnce();
+  });
+
+  test("sets consent localStorage key after accepting", async () => {
+    renderModal();
+
+    fireEvent.click(screen.getByRole("checkbox"));
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /am înțeles, continuă/i }));
+    });
+
+    expect(localStorage.getItem(CONSENT_KEY)).toBe("1");
+  });
+
+  test("admin modal shows different title and button", () => {
+    renderModal({ isAdmin: true });
+    expect(screen.getByText("Acces administrare materiale")).toBeTruthy();
+    expect(screen.getByRole("button", { name: /am înțeles$/i })).toBeTruthy();
+  });
+
+  test("admin does NOT see consent checkbox", () => {
+    renderModal({ isAdmin: true });
+    expect(screen.queryByRole("checkbox")).toBeNull();
+  });
+
+  test("admin accept calls onAccepted immediately", async () => {
+    const onAccepted = vi.fn();
+    renderModal({ isAdmin: true, onAccepted });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /am înțeles$/i }));
+    });
+
+    expect(onAccepted).toHaveBeenCalledOnce();
+  });
+
+  test("posts consent to API when non-admin accepts", async () => {
+    const fetchMock = vi.fn(() => Promise.resolve({ ok: true, json: async () => ({}) }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderModal();
+    fireEvent.click(screen.getByRole("checkbox"));
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /am înțeles, continuă/i }));
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/album/test-album/consent",
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+});

--- a/tests/vitest/client/pages/MediaDownload/OnboardingWizard.test.tsx
+++ b/tests/vitest/client/pages/MediaDownload/OnboardingWizard.test.tsx
@@ -1,0 +1,100 @@
+import React from "react";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import { describe, expect, test, vi, beforeEach } from "vitest";
+import OnboardingWizard from "src/client/pages/MediaDownload/Onboardingwizard";
+
+const STORAGE_KEY = "av:onboarding:done";
+
+// Minimal DOM stubs for elements the wizard targets
+function mountTargets() {
+  const mockRect = { top: 100, bottom: 200, left: 50, right: 250, width: 200, height: 100 } as DOMRect;
+
+  const photo = document.createElement("div");
+  photo.setAttribute("data-onboarding", "photo");
+  photo.getBoundingClientRect = () => mockRect;
+  photo.scrollIntoView = vi.fn();
+  document.body.appendChild(photo);
+
+  const pagerNext = document.createElement("button");
+  pagerNext.setAttribute("data-onboarding", "pager-next");
+  pagerNext.getBoundingClientRect = () => ({ top: 300, bottom: 340, left: 200, right: 280, width: 80, height: 40 } as DOMRect);
+  pagerNext.scrollIntoView = vi.fn();
+  document.body.appendChild(pagerNext);
+
+  return () => {
+    document.body.removeChild(photo);
+    document.body.removeChild(pagerNext);
+  };
+}
+
+describe("OnboardingWizard", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.useFakeTimers();
+  });
+
+  test("does NOT auto-start on mount without forceShow", () => {
+    const cleanup = mountTargets();
+    render(<OnboardingWizard />);
+    // No tooltip should appear without forceShow
+    expect(screen.queryByRole("button", { name: /sari peste/i })).toBeNull();
+    cleanup();
+  });
+
+  test("starts when forceShow=true and calls onStart", async () => {
+    const onStart = vi.fn();
+    const cleanup = mountTargets();
+
+    render(<OnboardingWizard forceShow={true} onStart={onStart} />);
+    act(() => { vi.runAllTimers(); });
+
+    expect(onStart).toHaveBeenCalledOnce();
+    cleanup();
+  });
+
+  test("shows prominent skip button during tutorial", async () => {
+    const cleanup = mountTargets();
+
+    render(<OnboardingWizard forceShow={true} />);
+    act(() => { vi.runAllTimers(); });
+
+    expect(screen.getByText(/sari peste tutorial/i)).toBeTruthy();
+    cleanup();
+  });
+
+  test("skip button calls onClose and sets localStorage", async () => {
+    const onClose = vi.fn();
+    const cleanup = mountTargets();
+
+    render(<OnboardingWizard forceShow={true} onClose={onClose} />);
+    act(() => { vi.runAllTimers(); });
+
+    fireEvent.click(screen.getByText(/sari peste tutorial/i));
+
+    expect(onClose).toHaveBeenCalledOnce();
+    expect(localStorage.getItem(STORAGE_KEY)).toBe("1");
+    cleanup();
+  });
+
+  test("step counter shows 1 / N on first step", async () => {
+    const cleanup = mountTargets();
+
+    render(<OnboardingWizard forceShow={true} />);
+    act(() => { vi.runAllTimers(); });
+
+    const indicator = screen.getByText(/1\s*\/\s*\d+/);
+    expect(indicator).toBeTruthy();
+    cleanup();
+  });
+
+  test("does not start when forceShow=false", () => {
+    const onStart = vi.fn();
+    const cleanup = mountTargets();
+
+    render(<OnboardingWizard forceShow={false} onStart={onStart} />);
+    act(() => { vi.runAllTimers(); });
+
+    expect(onStart).not.toHaveBeenCalled();
+    cleanup();
+  });
+});

--- a/tests/vitest/client/pages/MediaDownload/PhotoLightbox.test.tsx
+++ b/tests/vitest/client/pages/MediaDownload/PhotoLightbox.test.tsx
@@ -1,0 +1,111 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, expect, test, vi, beforeEach } from "vitest";
+import PhotoLightbox from "src/client/pages/MediaDownload/PhotoLightbox";
+
+const PHOTOS = [
+  "https://cdn.example.com/photo1.jpg",
+  "https://cdn.example.com/photo2.jpg",
+  "https://cdn.example.com/photo3.jpg",
+];
+
+function renderLightbox(overrides: Partial<React.ComponentProps<typeof PhotoLightbox>> = {}) {
+  return render(
+    <PhotoLightbox
+      photos={PHOTOS}
+      currentIndex={1}
+      onClose={vi.fn()}
+      onNext={vi.fn()}
+      onPrev={vi.fn()}
+      {...overrides}
+    />,
+  );
+}
+
+describe("PhotoLightbox", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("renders the current photo", () => {
+    renderLightbox();
+    const img = screen.getByRole("img") as HTMLImageElement;
+    expect(img.src).toContain("photo2.jpg");
+  });
+
+  test("shows counter with correct position", () => {
+    renderLightbox({ currentIndex: 1 });
+    expect(screen.getByText("2 / 3")).toBeTruthy();
+  });
+
+  test("calls onNext when next button clicked", () => {
+    const onNext = vi.fn();
+    renderLightbox({ onNext });
+    fireEvent.click(screen.getByLabelText("Poza următoare"));
+    expect(onNext).toHaveBeenCalledOnce();
+  });
+
+  test("calls onPrev when prev button clicked", () => {
+    const onPrev = vi.fn();
+    renderLightbox({ onPrev });
+    fireEvent.click(screen.getByLabelText("Poza anterioară"));
+    expect(onPrev).toHaveBeenCalledOnce();
+  });
+
+  test("prev button is disabled on first photo", () => {
+    renderLightbox({ currentIndex: 0 });
+    expect(screen.getByLabelText("Poza anterioară")).toBeDisabled();
+  });
+
+  test("next button is disabled on last photo", () => {
+    renderLightbox({ currentIndex: 2 });
+    expect(screen.getByLabelText("Poza următoare")).toBeDisabled();
+  });
+
+  test("print button not rendered without onTogglePrint prop", () => {
+    renderLightbox();
+    expect(screen.queryByLabelText(/imprimare/i)).toBeNull();
+  });
+
+  test("print button text is wrapped in span for mobile hiding", () => {
+    const { container } = renderLightbox({
+      selectedPrint: new Set(),
+      onTogglePrint: vi.fn(),
+      getFileName: (_src, index) => `photo${index + 1}.jpg`,
+    });
+
+    const printBtn = screen.getByLabelText("Adaugă la imprimare");
+    const span = printBtn.querySelector("span");
+    expect(span).toBeTruthy();
+    expect(span!.textContent).toContain("Adaugă la imprimare");
+  });
+
+  test("print button shows active label when photo is in print set", () => {
+    renderLightbox({
+      selectedPrint: new Set(["photo2.jpg"]),
+      onTogglePrint: vi.fn(),
+      getFileName: (_src, index) => `photo${index + 1}.jpg`,
+    });
+
+    expect(screen.getByLabelText("Elimină din imprimare")).toBeTruthy();
+  });
+
+  test("onTogglePrint called with correct filename when print button clicked", () => {
+    const onTogglePrint = vi.fn();
+    renderLightbox({
+      selectedPrint: new Set(),
+      onTogglePrint,
+      getFileName: (_src, index) => `photo${index + 1}.jpg`,
+    });
+
+    fireEvent.click(screen.getByLabelText("Adaugă la imprimare"));
+    expect(onTogglePrint).toHaveBeenCalledWith("photo2.jpg");
+  });
+
+  test("Escape key calls onClose", () => {
+    const onClose = vi.fn();
+    renderLightbox({ onClose });
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+});

--- a/tests/vitest/server/notifications/templates/contractEmail.test.ts
+++ b/tests/vitest/server/notifications/templates/contractEmail.test.ts
@@ -29,7 +29,7 @@ describe("contractEmail helpers", () => {
   });
 
   describe("happy path", () => {
-    test("sendContractLinkEmail builds the public signing link and subject", async () => {
+    test("sendContractLinkEmail sends to client first then copies admin", async () => {
       const { sendContractLinkEmail, sendMailMock } = await buildModule();
 
       await sendContractLinkEmail({
@@ -40,13 +40,33 @@ describe("contractEmail helpers", () => {
         baseUrl: "https://ancavisuals.ro",
       });
 
-      expect(sendMailMock).toHaveBeenCalledTimes(1);
-      expect(sendMailMock).toHaveBeenCalledWith(expect.objectContaining({
+      expect(sendMailMock).toHaveBeenCalledTimes(2);
+      expect(sendMailMock).toHaveBeenNthCalledWith(1, expect.objectContaining({
         from: "studio@ancavisuals.ro",
         to: "client@example.com",
         subject: expect.stringContaining("Contract servicii foto/video"),
         html: expect.stringContaining("https://ancavisuals.ro/contract/token-1"),
       }));
+      expect(sendMailMock).toHaveBeenNthCalledWith(2, expect.objectContaining({
+        to: "admin@ancavisuals.ro",
+        subject: expect.stringContaining("[Copie] Link contract trimis"),
+        html: expect.stringContaining("https://ancavisuals.ro/contract/token-1"),
+      }));
+    });
+
+    test("sendContractLinkEmail does not send admin copy if client delivery fails", async () => {
+      const { sendContractLinkEmail, sendMailMock } = await buildModule();
+      sendMailMock.mockRejectedValueOnce(new Error("SMTP connection refused"));
+
+      await expect(sendContractLinkEmail({
+        to: "client@example.com",
+        token: "token-1",
+        eventType: "Nuntă",
+        eventDate: "2026-09-12",
+        baseUrl: "https://ancavisuals.ro",
+      })).rejects.toThrow("SMTP connection refused");
+
+      expect(sendMailMock).toHaveBeenCalledTimes(1);
     });
 
     test("sendSignedContractEmail sends one mail to the client and one to admin with a download link", async () => {

--- a/tests/vitest/server/routes/contracts.routes.test.ts
+++ b/tests/vitest/server/routes/contracts.routes.test.ts
@@ -55,6 +55,11 @@ async function loadContractsRouter() {
     })),
   }));
 
+  vi.doMock("src/server/middleware/requireFirebaseAuth", () => ({
+    requireFirebaseAuth: (_req: any, _res: any, next: () => void) => next(),
+    requireSupremeAdmin: (_req: any, _res: any, next: () => void) => next(),
+  }));
+
   vi.doMock("src/server/firestore", () => ({
     firestore: () => ({
       collection: collectionMock,
@@ -94,7 +99,8 @@ async function loadContractsRouter() {
     if (!layer) {
       throw new Error(`Missing ${method.toUpperCase()} handler for ${path}`);
     }
-    return layer.route.stack[0].handle;
+    const stack = layer.route.stack;
+    return stack[stack.length - 1].handle;
   };
 
   return {
@@ -111,6 +117,7 @@ async function loadContractsRouter() {
     getPublicSign: getHandler("get", "/sign/:token"),
     postPublicSign: getHandler("post", "/sign/:token"),
     postSend: getHandler("post", "/:id/send"),
+    postResend: getHandler("post", "/:id/resend"),
   };
 }
 
@@ -391,6 +398,64 @@ describe("contracts.routes", () => {
         status: "signed",
         pdfUrl: null,
       });
+    });
+
+    test("POST /:id/resend responds immediately and triggers PDF email in background for signed contracts", async () => {
+      const { postResend, docGetMock, generateContractPDFMock, sendSignedContractEmailMock } = await loadContractsRouter();
+      const res = createMockResponse();
+
+      docGetMock.mockResolvedValue({
+        exists: true,
+        data: () => ({
+          status: "signed",
+          clientEmail: "client@example.com",
+          eventType: "Nunta",
+          eventDate: "2026-09-12",
+          clientName: "Ion Popescu",
+          token: "token-1",
+        }),
+      });
+
+      await postResend({ params: { id: "contract-1" } }, res);
+
+      expect(res.json).toHaveBeenCalledWith({ ok: true });
+
+      await flushPromises();
+
+      expect(generateContractPDFMock).toHaveBeenCalledTimes(1);
+      expect(sendSignedContractEmailMock).toHaveBeenCalledTimes(1);
+      expect(sendSignedContractEmailMock).toHaveBeenCalledWith(expect.objectContaining({
+        to: "client@example.com",
+        eventType: "Nunta",
+        clientName: "Ion Popescu",
+      }));
+    });
+
+    test("POST /:id/resend rejects unsigned contracts", async () => {
+      const { postResend, docGetMock } = await loadContractsRouter();
+      const res = createMockResponse();
+
+      docGetMock.mockResolvedValue({
+        exists: true,
+        data: () => ({ status: "sent", clientEmail: "client@example.com" }),
+      });
+
+      await postResend({ params: { id: "contract-1" } }, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith({ error: "Contractul nu este semnat." });
+    });
+
+    test("POST /:id/resend returns 404 for unknown contract", async () => {
+      const { postResend, docGetMock } = await loadContractsRouter();
+      const res = createMockResponse();
+
+      docGetMock.mockResolvedValue({ exists: false });
+
+      await postResend({ params: { id: "unknown" } }, res);
+
+      expect(res.status).toHaveBeenCalledWith(404);
+      expect(res.json).toHaveBeenCalledWith({ error: "Contract negăsit." });
     });
 
     test("POST /:id/send rejects contracts that are already signed", async () => {


### PR DESCRIPTION
- Onboarding wizard auto-starts after consent acceptance (non-admin only)
- Added prominent fixed "Sari peste tutorial" button at top during wizard
- Wizard no longer auto-starts on page load; parent controls lifecycle
- Expanded wizard from 5 to 9 steps: pager arrows each get own step, print zone preview step added
- Tutorial print preview: 6 random album photos shown temporarily during onboarding (localStorage only, never saved to DB)
- AlbumPager: added data-onboarding attributes on all nav buttons (pager-prev, pager-next, pager-first, pager-last, pager-input)
- PhotoLightbox: print button collapses to icon-only circle on mobile (span hides text via CSS)
- Fixed onboarding backdrop: transparent backdrop div, darkness comes from highlight box-shadow only so highlighted elements stay clear
- Hide "Vezi adresa de livrare" button when no delivery address saved
- Contract: added reminder email route and "Email re-amintire" button for unsigned contracts
- Contract: resend now sends admin copy sequentially (client first, then admin)
- Analytics: added 3-day period, topReferrers, topCountries; removed half-year/year periods
- Added 41 new tests: OnboardingWizard, PhotoLightbox, AlbumPager, MediaConsentModal