### PR TITLE
fix(gallery): resolve blank photo gallery on mobile (lazy-load height…

### DIFF
--- a/src/client/pages/Portfolio/BunnyPhotoGallery.module.scss
+++ b/src/client/pages/Portfolio/BunnyPhotoGallery.module.scss
@@ -52,7 +52,7 @@ $pg-shadow-hover: 0 18px 40px rgba(0, 0, 0, 0.95);
   width: 100%;
   padding: 0;
   border: none;
-  background: transparent;
+  background: #141414;
   border-radius: $pg-radius;
   overflow: hidden;
   box-shadow: $pg-shadow;
@@ -113,6 +113,7 @@ $pg-shadow-hover: 0 18px 40px rgba(0, 0, 0, 0.95);
   display: block;
   width: 100%;
   height: auto;
+  aspect-ratio: 2 / 3;
   object-fit: initial;
   transition:
     transform 0.32s ease,


### PR DESCRIPTION
… collapse)

## Problem
Client reported photos not visible at /media/8mai2026 on mobile (iOS Safari). Pager showed correct count (446 photos, 23 pages) but gallery area appeared empty.

## Root Cause
Images used `loading="lazy"` + `height: auto` with no intrinsic dimensions before load. Before an image loads, its rendered height is 0. The masonry gallery items collapsed to 0px height → browser lazy-load algorithm couldn't determine viewport proximity → images never triggered loading → gallery appeared completely blank.

Desktop was unaffected (wider viewport, gallery higher on page, different lazy-load threshold in Chromium vs iOS Safari).

Verified via Playwright: all 20 thumbnail URLs returned HTTP 200 — CDN was fine. DOM had all 20 buttons rendered. Pure CSS/layout issue.

## Fix
- `.pg-img`: added `aspect-ratio: 2 / 3` — reserves portrait placeholder height before image loads; once image loads, intrinsic aspect ratio takes priority (CSS spec: intrinsic ratio overrides aspect-ratio for replaced elements), so each photo renders at its actual proportions
- `.pg-item`: changed `background: transparent` → `background: #141414` — makes placeholder boxes visible so users see loading state instead of void