### PR TITLE
feat: venue outreach tool with SMSAlert integration

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -44,6 +44,7 @@ import weddingChecklistRouter from "./src/server/routes/weddingChecklist.routes"
 import weddingTimelineRouter from "./src/server/routes/weddingTimeline.routes";
 import weddingRemindersRouter from "./src/server/routes/weddingReminders.routes";
 import oferteRouter from "./src/server/routes/oferte.routes";
+import venueOutreachRouter from "./src/server/routes/venueOutreach.routes";
 import { startMementosCron } from "./src/server/cron/mementos.cron";
 import { startAnalyticsCron } from "./src/server/cron/analytics.cron";
 import { startAlbumRetentionCron } from "./src/server/cron/albumRetention.cron";
@@ -155,6 +156,7 @@ async function createServer() {
   app.use(API_ROUTE_PREFIXES.admin, inspirationRouter);
   app.use(API_ROUTE_PREFIXES.admin, mementosRouter);
   app.use(API_ROUTE_PREFIXES.admin, accountsRouter);
+  app.use(API_ROUTE_PREFIXES.admin, venueOutreachRouter);
   app.use("/api/analytics", analyticsPublicRouter);
   app.use(API_ROUTE_PREFIXES.admin, analyticsAdminRouter);
   app.use("/api/moderare", moderationRouter);

--- a/src/client/features/admin/components/AdminSidebar.tsx
+++ b/src/client/features/admin/components/AdminSidebar.tsx
@@ -160,6 +160,7 @@ const AdminSidebar: React.FC<AdminSidebarProps> = ({ open, onClose }) => {
         { label: "Landing page", path: "/admin/landing" },
         { label: "Inspirație", path: "/admin/inspiration" },
         { label: "Analytics", path: "/admin/analytics" },
+        { label: "Venue Outreach", path: "/admin/venue-outreach" },
       ],
     },
     {

--- a/src/client/features/admin/components/VenueOutreachPage.tsx
+++ b/src/client/features/admin/components/VenueOutreachPage.tsx
@@ -1,0 +1,636 @@
+import React, { useState, useEffect } from "react";
+import useAuth from "../auth/useAuth";
+
+interface Venue {
+  placeId: string;
+  slug: string;
+  name: string;
+  address: string;
+  rating?: number;
+  reviewCount?: number;
+  phone: string | null;
+  website: string | null;
+  types: string[];
+}
+
+interface LogEntry {
+  id: string;
+  placeId: string;
+  name: string;
+  city: string;
+  address: string;
+  phone: string | null;
+  website: string | null;
+  channel: "whatsapp" | "email" | "sms";
+  sentAt: string;
+}
+
+const CITIES = [
+  // Cluj county
+  "Cluj-Napoca", "Turda", "Dej", "Gherla", "Huedin", "Câmpia Turzii", "Câmpeni",
+  // Alba county
+  "Alba Iulia", "Blaj", "Sebeș", "Aiud", "Cugir", "Abrud", "Ocna Mureș", "Teiuș",
+  // Sibiu county
+  "Sibiu", "Mediaș", "Cisnădie", "Avrig", "Agnita", "Dumbrăveni", "Miercurea Sibiului",
+  // Brașov county
+  "Brașov", "Codlea", "Zărnești", "Predeal", "Sinaia", "Făgăraș", "Rupea",
+  // Mureș county
+  "Târgu Mureș", "Reghin", "Sighișoara", "Sovata", "Luduș", "Târgu Lăpuș",
+  // Bistrița-Năsăud county
+  "Bistrița", "Beclean", "Năsăud", "Sângeorz-Băi",
+  // Harghita county
+  "Miercurea Ciuc", "Odorheiu Secuiesc", "Gheorgheni", "Toplița", "Cristuru Secuiesc",
+  // Covasna county
+  "Sfântu Gheorghe", "Târgu Secuiesc",
+  // Hunedoara county
+  "Deva", "Hunedoara", "Petroșani", "Orăștie", "Brad",
+  // Bihor (Oradea area)
+  "Oradea", "Salonta", "Beiuș", "Marghita", "Aleșd",
+  // Arad county
+  "Arad", "Lipova", "Ineu", "Sebiș", "Curtici",
+  // Timiș county
+  "Timișoara", "Lugoj",
+  // Satu Mare county
+  "Satu Mare", "Carei",
+  // Maramureș county
+  "Baia Mare", "Sighetu Marmației", "Vișeu de Sus",
+  // Sălaj county
+  "Zalău", "Șimleu Silvaniei",
+];
+
+const MESSAGE_TEMPLATES = {
+  whatsapp: (venueName: string) =>
+    `Bună ziua! 👋\n\nSuntem AncaVisuals, o echipă foto-video specializată în nunți, botezuri și majorate.\n\nAm admirat locația dumneavoastră — ${venueName} — și ne-am dori să discutăm o posibilă colaborare.\n\nMulți dintre clienții care rezervă la dumneavoastră caută și un fotograf/cameraman. Am putea fi recomandați reciproc.\n\nPortofoliul nostru: ancavisuals.ro\n\nVă mulțumim!`,
+  email: (venueName: string) =>
+    `Bună ziua,\n\nSuntem echipa AncaVisuals, specializați în fotografie și videografie pentru nunți, botezuri și majorate.\n\nAm observat că ${venueName} este o locație apreciată pentru evenimente speciale și ne-am dori să explorăm o posibilă colaborare de recomandare reciprocă.\n\nClienții dumneavoastră care organizează nunți sau botezuri au nevoie și de servicii foto-video profesionale. Am fi bucuroși să fim recomandați și, la rândul nostru, să vă promovăm locația clienților noștri.\n\nPortofoliu complet: ancavisuals.ro\n\nSuntem disponibili pentru o discuție oricând.\n\nCu stimă,\nEchipa AncaVisuals`,
+  emailSubject: (venueName: string) => `Propunere colaborare foto-video — AncaVisuals & ${venueName}`,
+  sms: () =>
+    `Bună! Suntem AncaVisuals, echipă foto-video pentru nunți și evenimente. Dorim colaborare cu locații de evenimente. Portofoliu: ancavisuals.ro`,
+};
+
+type Tab = "search" | "contacted";
+type ChannelFilter = "all" | "whatsapp" | "email" | "sms";
+type ChannelToggle = Set<"whatsapp" | "email" | "sms">;
+
+export default function VenueOutreachPage() {
+  const { auth } = useAuth();
+  const authHeader = { Authorization: `Bearer ${auth.accessToken}` };
+
+  const [tab, setTab] = useState<Tab>("search");
+  const [city, setCity] = useState("Cluj-Napoca");
+  const [customCity, setCustomCity] = useState("");
+  const [keyword, setKeyword] = useState("");
+  const [venues, setVenues] = useState<Venue[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [activeTemplate, setActiveTemplate] = useState<"whatsapp" | "email" | "sms">("whatsapp");
+  const [customMessage, setCustomMessage] = useState("");
+  const [editingTemplate, setEditingTemplate] = useState(false);
+
+  const [visibleChannels, setVisibleChannels] = useState<ChannelToggle>(new Set(["whatsapp", "email", "sms"]));
+  const [sendingIds, setSendingIds] = useState<Set<string>>(new Set());
+  const [sendErrors, setSendErrors] = useState<Record<string, string>>({});
+  const [venueEmails, setVenueEmails] = useState<Record<string, string>>({});
+
+  // Persistent log
+  const [logEntries, setLogEntries] = useState<LogEntry[]>([]);
+  const [logLoading, setLogLoading] = useState(false);
+  const [contactedIds, setContactedIds] = useState<Set<string>>(new Set());
+  const [channelFilter, setChannelFilter] = useState<ChannelFilter>("all");
+
+  const effectiveCity = customCity.trim() || city;
+
+  useEffect(() => {
+    if (!auth.accessToken) return;
+    setLogLoading(true);
+    fetch("/api/admin/venue-outreach/log", { headers: authHeader })
+      .then((response) => response.json())
+      .then((data: { entries?: LogEntry[] }) => {
+        const entries = data.entries ?? [];
+        setLogEntries(entries);
+        setContactedIds(new Set(entries.map((entry) => entry.placeId)));
+      })
+      .catch(() => {})
+      .finally(() => setLogLoading(false));
+  }, [auth.accessToken]);
+
+  const saveToLog = async (venue: Venue, channel: "whatsapp" | "email" | "sms") => {
+    try {
+      await fetch("/api/admin/venue-outreach/log", {
+        method: "POST",
+        headers: { ...authHeader, "Content-Type": "application/json" },
+        body: JSON.stringify({
+          placeId: venue.placeId,
+          name: venue.name,
+          city: effectiveCity,
+          address: venue.address,
+          phone: venue.phone,
+          website: venue.website,
+          channel,
+        }),
+      });
+      const newEntry: LogEntry = {
+        id: Date.now().toString(),
+        placeId: venue.placeId,
+        name: venue.name,
+        city: effectiveCity,
+        address: venue.address,
+        phone: venue.phone,
+        website: venue.website,
+        channel,
+        sentAt: new Date().toISOString(),
+      };
+      setLogEntries((prev) => [newEntry, ...prev]);
+      setContactedIds((prev) => new Set([...prev, venue.placeId]));
+    } catch {
+      // log save failure is non-blocking
+    }
+  };
+
+  const loadTestVenue = () => {
+    setVenues([{
+      placeId: "test-daniel",
+      slug: "test-daniel",
+      name: "TEST — Daniel",
+      address: "Cluj-Napoca, România",
+      rating: 5,
+      reviewCount: 1,
+      phone: "0745469907",
+      website: "https://ancavisuals.ro",
+      types: ["test"],
+    }]);
+    setSelected(new Set());
+    setVenueEmails({});
+  };
+
+  const search = async () => {
+    setLoading(true);
+    setError(null);
+    setVenues([]);
+    setSelected(new Set());
+    setVenueEmails({});
+    try {
+      const params = new URLSearchParams();
+      if (keyword.trim()) {
+        params.set("keyword", keyword.trim());
+        if (effectiveCity) params.set("city", effectiveCity);
+      } else {
+        params.set("city", effectiveCity);
+      }
+      const response = await fetch(`/api/admin/venue-outreach/search?${params.toString()}`, { headers: authHeader });
+      const data = (await response.json()) as { venues?: Venue[]; error?: string };
+      if (!response.ok) throw new Error(data.error ?? "Eroare necunoscută");
+      setVenues(data.venues ?? []);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Eroare la căutare");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const toggleSelect = (placeId: string) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(placeId)) next.delete(placeId);
+      else next.add(placeId);
+      return next;
+    });
+  };
+
+  const toggleAll = () => {
+    if (selected.size === venues.length) setSelected(new Set());
+    else setSelected(new Set(venues.map((venue) => venue.placeId)));
+  };
+
+  const getTemplate = (venue: Venue) => {
+    const base = customMessage.trim();
+    if (base) return base;
+    if (activeTemplate === "whatsapp") return MESSAGE_TEMPLATES.whatsapp(venue.name);
+    if (activeTemplate === "sms") return MESSAGE_TEMPLATES.sms();
+    return MESSAGE_TEMPLATES.email(venue.name);
+  };
+
+  const toggleChannel = (ch: "whatsapp" | "email" | "sms") => {
+    setVisibleChannels((prev) => {
+      const next = new Set(prev);
+      if (next.has(ch)) next.delete(ch);
+      else next.add(ch);
+      return next;
+    });
+  };
+
+  const sendViaApi = async (venue: Venue, channel: "whatsapp" | "sms") => {
+    if (!venue.phone) return;
+    const key = `${venue.placeId}-${channel}`;
+    setSendingIds((prev) => new Set([...prev, key]));
+    setSendErrors((prev) => { const next = { ...prev }; delete next[key]; return next; });
+    try {
+      const response = await fetch("/api/admin/venue-outreach/send", {
+        method: "POST",
+        headers: { ...authHeader, "Content-Type": "application/json" },
+        body: JSON.stringify({ phone: venue.phone, message: getTemplate(venue), channel }),
+      });
+      const data = (await response.json()) as { ok?: boolean; error?: string };
+      if (!response.ok) {
+        setSendErrors((prev) => ({ ...prev, [key]: data.error ?? "Eroare trimitere" }));
+        return;
+      }
+      void saveToLog(venue, channel);
+    } catch {
+      setSendErrors((prev) => ({ ...prev, [key]: "Eroare conexiune" }));
+    } finally {
+      setSendingIds((prev) => { const next = new Set(prev); next.delete(key); return next; });
+    }
+  };
+
+  const sendWhatsApp = (venue: Venue) => void sendViaApi(venue, "whatsapp");
+
+  const sendEmail = (venue: Venue) => {
+    const subject = encodeURIComponent(MESSAGE_TEMPLATES.emailSubject(venue.name));
+    const body = encodeURIComponent(getTemplate(venue));
+    const to = encodeURIComponent(venueEmails[venue.placeId] ?? "");
+    window.open(`https://mail.google.com/mail/?view=cm&fs=1&to=${to}&su=${subject}&body=${body}`, "_blank");
+    void saveToLog(venue, "email");
+  };
+
+  const sendSms = (venue: Venue) => void sendViaApi(venue, "sms");
+
+  const sendBulk = () => {
+    const targets = venues.filter((venue) => selected.has(venue.placeId));
+    for (const venue of targets) {
+      if (activeTemplate === "whatsapp" && venue.phone) sendWhatsApp(venue);
+      else if (activeTemplate === "email") sendEmail(venue);
+      else if (activeTemplate === "sms" && venue.phone) sendSms(venue);
+    }
+  };
+
+  const selectedVenues = venues.filter((venue) => selected.has(venue.placeId));
+  const contactableSelected = selectedVenues.filter((venue) =>
+    activeTemplate === "email" ? true : !!venue.phone
+  );
+
+  const filteredLog = channelFilter === "all"
+    ? logEntries
+    : logEntries.filter((entry) => entry.channel === channelFilter);
+
+  const channelLabel = { whatsapp: "WhatsApp", email: "Email", sms: "SMS" };
+  const channelColor = {
+    whatsapp: { bg: "#25D36622", border: "#25D36644", text: "#25D366" },
+    email: { bg: "#2244aa22", border: "#2244aa44", text: "#6af" },
+    sms: { bg: "#4a9922", border: "#4a9944", text: "#7d3" },
+  };
+
+  return (
+    <div style={{ padding: "24px", maxWidth: 960, margin: "0 auto" }}>
+      <h1 style={{ fontSize: 22, fontWeight: 700, marginBottom: 4 }}>Venue Outreach</h1>
+      <p style={{ color: "#888", fontSize: 13, marginBottom: 20 }}>
+        Caută restaurante și săli de evenimente și trimite-le un mesaj de colaborare.
+      </p>
+
+      {/* Tabs */}
+      <div style={{ display: "flex", gap: 4, marginBottom: 24, borderBottom: "1px solid #222" }}>
+        {(["search", "contacted"] as Tab[]).map((t) => (
+          <button
+            key={t}
+            onClick={() => setTab(t)}
+            style={{
+              padding: "8px 16px", background: "none", border: "none", cursor: "pointer",
+              fontSize: 14, fontWeight: 600,
+              color: tab === t ? "#c9a96e" : "#666",
+              borderBottom: tab === t ? "2px solid #c9a96e" : "2px solid transparent",
+              marginBottom: -1,
+            }}
+          >
+            {t === "search" ? "Căutare" : `Contactate (${logEntries.length})`}
+          </button>
+        ))}
+      </div>
+
+      {tab === "search" && (
+        <>
+          {/* Search bar */}
+          <div style={{ display: "flex", gap: 10, marginBottom: 16, flexWrap: "wrap", alignItems: "center" }}>
+            <select
+              value={city}
+              onChange={(e) => { setCity(e.target.value); setCustomCity(""); }}
+              style={{ padding: "8px 12px", borderRadius: 8, border: "1px solid #333", background: "#1a1a1a", color: "#fff", fontSize: 14 }}
+            >
+              {CITIES.map((c) => <option key={c} value={c}>{c}</option>)}
+            </select>
+            <input
+              placeholder="Alt oraș..."
+              value={customCity}
+              onChange={(e) => setCustomCity(e.target.value)}
+              style={{ padding: "8px 12px", borderRadius: 8, border: "1px solid #333", background: "#1a1a1a", color: "#fff", fontSize: 14, width: 160 }}
+            />
+            <span style={{ color: "#555", fontSize: 13 }}>sau</span>
+            <input
+              placeholder='Cuvânt cheie (ex: "Ballroom", "Events")'
+              value={keyword}
+              onChange={(e) => setKeyword(e.target.value)}
+              onKeyDown={(e) => e.key === "Enter" && search()}
+              style={{ padding: "8px 12px", borderRadius: 8, border: "1px solid #333", background: "#1a1a1a", color: "#fff", fontSize: 14, width: 240 }}
+            />
+            <button
+              onClick={search}
+              disabled={loading}
+              style={{ padding: "8px 20px", borderRadius: 8, background: "#c9a96e", color: "#111", fontWeight: 700, border: "none", cursor: loading ? "not-allowed" : "pointer", opacity: loading ? 0.7 : 1 }}
+            >
+              {loading ? "Se caută..." : "Caută"}
+            </button>
+            <button
+              onClick={loadTestVenue}
+              style={{ padding: "8px 14px", borderRadius: 8, background: "transparent", color: "#555", fontWeight: 600, border: "1px solid #333", cursor: "pointer", fontSize: 12 }}
+            >
+              Test SMS
+            </button>
+          </div>
+
+          {error && (
+            <div style={{ background: "#2a1a1a", border: "1px solid #c44", borderRadius: 8, padding: "10px 14px", marginBottom: 16, color: "#f88", fontSize: 13 }}>
+              {error}
+            </div>
+          )}
+
+          {venues.length > 0 && (
+            <>
+              {/* Template selector */}
+              <div style={{ background: "#161616", border: "1px solid #2a2a2a", borderRadius: 10, padding: 16, marginBottom: 16 }}>
+                <div style={{ display: "flex", gap: 8, marginBottom: 12 }}>
+                  {(["whatsapp", "email", "sms"] as const).map((type) => (
+                    <button
+                      key={type}
+                      onClick={() => { setActiveTemplate(type); setEditingTemplate(false); setCustomMessage(""); }}
+                      style={{
+                        padding: "6px 14px", borderRadius: 6, border: "1px solid",
+                        borderColor: activeTemplate === type ? "#c9a96e" : "#333",
+                        background: activeTemplate === type ? "#c9a96e22" : "transparent",
+                        color: activeTemplate === type ? "#c9a96e" : "#888",
+                        fontWeight: 600, fontSize: 13, cursor: "pointer", textTransform: "uppercase",
+                      }}
+                    >
+                      {type === "whatsapp" ? "WhatsApp" : type === "email" ? "Email" : "SMS"}
+                    </button>
+                  ))}
+                  <button
+                    onClick={() => setEditingTemplate(!editingTemplate)}
+                    style={{ marginLeft: "auto", padding: "6px 12px", borderRadius: 6, border: "1px solid #333", background: "transparent", color: "#aaa", fontSize: 12, cursor: "pointer" }}
+                  >
+                    {editingTemplate ? "Resetează template" : "Editează mesaj"}
+                  </button>
+                </div>
+
+                {editingTemplate ? (
+                  <textarea
+                    value={customMessage || MESSAGE_TEMPLATES[activeTemplate === "email" ? "email" : activeTemplate === "sms" ? "sms" : "whatsapp"](venues[0]?.name ?? "Locație")}
+                    onChange={(e) => setCustomMessage(e.target.value)}
+                    rows={8}
+                    style={{ width: "100%", background: "#0f0f0f", border: "1px solid #333", borderRadius: 6, color: "#ddd", padding: 12, fontSize: 13, fontFamily: "monospace", resize: "vertical", boxSizing: "border-box" }}
+                  />
+                ) : (
+                  <pre style={{ background: "#0f0f0f", borderRadius: 6, padding: 12, color: "#bbb", fontSize: 12, whiteSpace: "pre-wrap", margin: 0, maxHeight: 180, overflow: "auto" }}>
+                    {MESSAGE_TEMPLATES[activeTemplate === "email" ? "email" : activeTemplate === "sms" ? "sms" : "whatsapp"](venues[0]?.name ?? "Locație")}
+                  </pre>
+                )}
+              </div>
+
+              {/* Channel toggles */}
+              <div style={{ display: "flex", gap: 8, marginBottom: 12, alignItems: "center", flexWrap: "wrap" }}>
+                <span style={{ fontSize: 12, color: "#666" }}>Afișează butoane:</span>
+                {(["whatsapp", "email", "sms"] as const).map((ch) => (
+                  <button
+                    key={ch}
+                    onClick={() => toggleChannel(ch)}
+                    style={{
+                      padding: "4px 10px", borderRadius: 6, border: "1px solid",
+                      borderColor: visibleChannels.has(ch) ? channelColor[ch].border : "#333",
+                      background: visibleChannels.has(ch) ? channelColor[ch].bg : "transparent",
+                      color: visibleChannels.has(ch) ? channelColor[ch].text : "#555",
+                      fontWeight: 600, fontSize: 11, cursor: "pointer", textTransform: "uppercase",
+                    }}
+                  >
+                    {channelLabel[ch]}
+                  </button>
+                ))}
+              </div>
+
+              {/* Bulk actions */}
+              <div style={{ display: "flex", alignItems: "center", gap: 12, marginBottom: 12 }}>
+                <button onClick={toggleAll} style={{ fontSize: 12, color: "#888", background: "none", border: "none", cursor: "pointer", textDecoration: "underline" }}>
+                  {selected.size === venues.length ? "Deselectează tot" : `Selectează tot (${venues.length})`}
+                </button>
+                {selected.size > 0 && (
+                  <>
+                    <span style={{ color: "#555", fontSize: 12 }}>|</span>
+                    <span style={{ fontSize: 12, color: "#aaa" }}>{selected.size} selectate</span>
+                    <button
+                      onClick={sendBulk}
+                      disabled={contactableSelected.length === 0}
+                      style={{ padding: "6px 14px", borderRadius: 6, background: "#c9a96e", color: "#111", fontWeight: 700, border: "none", cursor: "pointer", fontSize: 13, opacity: contactableSelected.length === 0 ? 0.4 : 1 }}
+                    >
+                      Trimite {activeTemplate.toUpperCase()} ({contactableSelected.length})
+                    </button>
+                  </>
+                )}
+                <span style={{ marginLeft: "auto", color: "#555", fontSize: 12 }}>{venues.length} locații găsite</span>
+              </div>
+
+              {/* Venue list */}
+              <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+                {venues.map((venue) => {
+                  const isSelected = selected.has(venue.placeId);
+                  const isContacted = contactedIds.has(venue.placeId);
+
+                  return (
+                    <div
+                      key={venue.placeId}
+                      style={{
+                        background: isSelected ? "#1a1a12" : "#111",
+                        border: `1px solid ${isSelected ? "#c9a96e44" : isContacted ? "#4a944" : "#222"}`,
+                        borderRadius: 10,
+                        padding: "12px 16px",
+                        display: "flex",
+                        alignItems: "center",
+                        gap: 12,
+                        opacity: isContacted ? 0.65 : 1,
+                      }}
+                    >
+                      <input
+                        type="checkbox"
+                        checked={isSelected}
+                        onChange={() => toggleSelect(venue.placeId)}
+                        style={{ width: 16, height: 16, cursor: "pointer", accentColor: "#c9a96e", flexShrink: 0 }}
+                      />
+
+                      <div style={{ flex: 1, minWidth: 0 }}>
+                        <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
+                          <span style={{ fontWeight: 600, fontSize: 14, color: "#fff" }}>{venue.name}</span>
+                          {venue.rating && (
+                            <span style={{ fontSize: 11, color: "#c9a96e", background: "#c9a96e18", padding: "2px 6px", borderRadius: 4 }}>
+                              ★ {venue.rating} ({venue.reviewCount})
+                            </span>
+                          )}
+                          {isContacted && (
+                            <span style={{ fontSize: 11, color: "#4a9", background: "#4a921a", padding: "2px 6px", borderRadius: 4 }}>Contactat</span>
+                          )}
+                        </div>
+                        <div style={{ fontSize: 12, color: "#666", marginTop: 2, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{venue.address}</div>
+                        <div style={{ display: "flex", gap: 8, marginTop: 4, flexWrap: "wrap" }}>
+                          {venue.phone && <span style={{ fontSize: 11, color: "#4a9" }}>📞 {venue.phone}</span>}
+                          {venue.website && (
+                            <a href={venue.website} target="_blank" rel="noopener noreferrer" style={{ fontSize: 11, color: "#6af" }}>
+                              🌐 {new URL(venue.website).hostname}
+                            </a>
+                          )}
+                          {!venue.phone && !venue.website && <span style={{ fontSize: 11, color: "#555" }}>Fără contact disponibil</span>}
+                        </div>
+                      </div>
+
+                      <div style={{ display: "flex", flexDirection: "column", gap: 4, alignItems: "flex-end", flexShrink: 0 }}>
+                        {venue.phone && (visibleChannels.has("whatsapp") || visibleChannels.has("sms")) && (
+                          <span style={{ fontSize: 12, color: "#888", fontFamily: "monospace", letterSpacing: "0.03em" }}>
+                            {venue.phone}
+                          </span>
+                        )}
+                        <div style={{ display: "flex", gap: 6 }}>
+                          {venue.phone && visibleChannels.has("whatsapp") && (
+                            <button
+                              onClick={() => sendWhatsApp(venue)}
+                              disabled={sendingIds.has(`${venue.placeId}-whatsapp`)}
+                              title="WhatsApp"
+                              style={{ padding: "6px 10px", borderRadius: 6, background: "#25D36622", border: "1px solid #25D36644", color: "#25D366", cursor: "pointer", fontSize: 13, opacity: sendingIds.has(`${venue.placeId}-whatsapp`) ? 0.5 : 1 }}
+                            >
+                              {sendingIds.has(`${venue.placeId}-whatsapp`) ? "..." : "WA"}
+                            </button>
+                          )}
+                          {venue.phone && visibleChannels.has("sms") && (
+                            <button
+                              onClick={() => sendSms(venue)}
+                              disabled={sendingIds.has(`${venue.placeId}-sms`)}
+                              title="SMS"
+                              style={{ padding: "6px 10px", borderRadius: 6, background: "#4a9922", border: "1px solid #4a9944", color: "#7d3", cursor: "pointer", fontSize: 13, opacity: sendingIds.has(`${venue.placeId}-sms`) ? 0.5 : 1 }}
+                            >
+                              {sendingIds.has(`${venue.placeId}-sms`) ? "..." : "SMS"}
+                            </button>
+                          )}
+                          {visibleChannels.has("email") && (
+                            <>
+                              <input
+                                type="email"
+                                placeholder="email@locatie.ro"
+                                value={venueEmails[venue.placeId] ?? ""}
+                                onChange={(e) => setVenueEmails((prev) => ({ ...prev, [venue.placeId]: e.target.value }))}
+                                style={{ padding: "5px 8px", borderRadius: 6, border: "1px solid #2244aa44", background: "#0f0f1a", color: "#aac", fontSize: 12, width: 150 }}
+                              />
+                              {venueEmails[venue.placeId]?.trim() && (
+                                <button
+                                  onClick={() => sendEmail(venue)}
+                                  title={venueEmails[venue.placeId]}
+                                  style={{ padding: "6px 10px", borderRadius: 6, background: "#2244aa22", border: "1px solid #2244aa44", color: "#6af", cursor: "pointer", fontSize: 13 }}
+                                >
+                                  Email
+                                </button>
+                              )}
+                            </>
+                          )}
+                        </div>
+                        {(sendErrors[`${venue.placeId}-whatsapp`] || sendErrors[`${venue.placeId}-sms`]) && (
+                          <span style={{ fontSize: 10, color: "#f66" }}>
+                            {sendErrors[`${venue.placeId}-whatsapp`] ?? sendErrors[`${venue.placeId}-sms`]}
+                          </span>
+                        )}
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            </>
+          )}
+
+          {!loading && venues.length === 0 && !error && (
+            <div style={{ textAlign: "center", padding: "60px 0", color: "#444", fontSize: 14 }}>
+              Selectează un oraș sau scrie un cuvânt cheie și apasă Caută.
+            </div>
+          )}
+        </>
+      )}
+
+      {tab === "contacted" && (
+        <>
+          {/* Channel filter */}
+          <div style={{ display: "flex", gap: 8, marginBottom: 16, flexWrap: "wrap", alignItems: "center" }}>
+            <span style={{ fontSize: 12, color: "#666" }}>Filtrează:</span>
+            {(["all", "whatsapp", "email", "sms"] as ChannelFilter[]).map((filter) => (
+              <button
+                key={filter}
+                onClick={() => setChannelFilter(filter)}
+                style={{
+                  padding: "5px 12px", borderRadius: 6, border: "1px solid",
+                  borderColor: channelFilter === filter ? "#c9a96e" : "#333",
+                  background: channelFilter === filter ? "#c9a96e22" : "transparent",
+                  color: channelFilter === filter ? "#c9a96e" : "#888",
+                  fontWeight: 600, fontSize: 12, cursor: "pointer", textTransform: "uppercase",
+                }}
+              >
+                {filter === "all" ? "Toate" : channelLabel[filter]}
+              </button>
+            ))}
+            <span style={{ marginLeft: "auto", color: "#555", fontSize: 12 }}>{filteredLog.length} înregistrări</span>
+          </div>
+
+          {logLoading && (
+            <div style={{ textAlign: "center", padding: "40px 0", color: "#555", fontSize: 14 }}>Se încarcă...</div>
+          )}
+
+          {!logLoading && filteredLog.length === 0 && (
+            <div style={{ textAlign: "center", padding: "60px 0", color: "#444", fontSize: 14 }}>
+              Nicio locație contactată încă.
+            </div>
+          )}
+
+          <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+            {filteredLog.map((entry) => {
+              const colors = channelColor[entry.channel];
+              return (
+                <div
+                  key={entry.id}
+                  style={{
+                    background: "#111", border: "1px solid #222", borderRadius: 10,
+                    padding: "12px 16px", display: "flex", alignItems: "center", gap: 12,
+                  }}
+                >
+                  <div style={{ flex: 1, minWidth: 0 }}>
+                    <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
+                      <span style={{ fontWeight: 600, fontSize: 14, color: "#fff" }}>{entry.name}</span>
+                      <span style={{ fontSize: 11, padding: "2px 6px", borderRadius: 4, background: colors.bg, border: `1px solid ${colors.border}`, color: colors.text }}>
+                        {channelLabel[entry.channel]}
+                      </span>
+                      {entry.city && (
+                        <span style={{ fontSize: 11, color: "#666" }}>{entry.city}</span>
+                      )}
+                    </div>
+                    <div style={{ fontSize: 12, color: "#555", marginTop: 2, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{entry.address}</div>
+                    <div style={{ display: "flex", gap: 8, marginTop: 4, flexWrap: "wrap" }}>
+                      {entry.phone && <span style={{ fontSize: 11, color: "#4a9" }}>📞 {entry.phone}</span>}
+                      {entry.website && (
+                        <a href={entry.website} target="_blank" rel="noopener noreferrer" style={{ fontSize: 11, color: "#6af" }}>
+                          🌐 {new URL(entry.website).hostname}
+                        </a>
+                      )}
+                    </div>
+                  </div>
+                  <div style={{ flexShrink: 0, fontSize: 11, color: "#555", textAlign: "right" }}>
+                    {new Date(entry.sentAt).toLocaleDateString("ro-RO", { day: "2-digit", month: "short", year: "numeric" })}
+                    <br />
+                    {new Date(entry.sentAt).toLocaleTimeString("ro-RO", { hour: "2-digit", minute: "2-digit" })}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/client/features/admin/components/VenueOutreachPage.tsx
+++ b/src/client/features/admin/components/VenueOutreachPage.tsx
@@ -58,14 +58,32 @@ const CITIES = [
   "Zalău", "Șimleu Silvaniei",
 ];
 
-const MESSAGE_TEMPLATES = {
-  whatsapp: (venueName: string) =>
-    `Bună ziua! 👋\n\nSuntem AncaVisuals, o echipă foto-video specializată în nunți, botezuri și majorate.\n\nAm admirat locația dumneavoastră — ${venueName} — și ne-am dori să discutăm o posibilă colaborare.\n\nMulți dintre clienții care rezervă la dumneavoastră caută și un fotograf/cameraman. Am putea fi recomandați reciproc.\n\nPortofoliul nostru: ancavisuals.ro\n\nVă mulțumim!`,
-  email: (venueName: string) =>
-    `Bună ziua,\n\nSuntem echipa AncaVisuals, specializați în fotografie și videografie pentru nunți, botezuri și majorate.\n\nAm observat că ${venueName} este o locație apreciată pentru evenimente speciale și ne-am dori să explorăm o posibilă colaborare de recomandare reciprocă.\n\nClienții dumneavoastră care organizează nunți sau botezuri au nevoie și de servicii foto-video profesionale. Am fi bucuroși să fim recomandați și, la rândul nostru, să vă promovăm locația clienților noștri.\n\nPortofoliu complet: ancavisuals.ro\n\nSuntem disponibili pentru o discuție oricând.\n\nCu stimă,\nEchipa AncaVisuals`,
-  emailSubject: (venueName: string) => `Propunere colaborare foto-video — AncaVisuals & ${venueName}`,
-  sms: () =>
-    `Bună! Suntem AncaVisuals, echipă foto-video pentru nunți și evenimente. Dorim colaborare cu locații de evenimente. Portofoliu: ancavisuals.ro`,
+type Category = "venue" | "rochii-mirese";
+
+const MESSAGE_TEMPLATES: Record<Category, {
+  whatsapp: (name: string) => string;
+  email: (name: string) => string;
+  emailSubject: (name: string) => string;
+  sms: () => string;
+}> = {
+  venue: {
+    whatsapp: (venueName) =>
+      `Bună ziua! 👋\n\nSuntem AncaVisuals, o echipă foto-video specializată în nunți, botezuri și majorate.\n\nAm admirat locația dumneavoastră — ${venueName} — și ne-am dori să discutăm o posibilă colaborare.\n\nMulți dintre clienții care rezervă la dumneavoastră caută și un fotograf/cameraman. Am putea fi recomandați reciproc.\n\nPortofoliul nostru: ancavisuals.ro\n\nVă mulțumim!`,
+    email: (venueName) =>
+      `Bună ziua,\n\nSuntem echipa AncaVisuals, specializați în fotografie și videografie pentru nunți, botezuri și majorate.\n\nAm observat că ${venueName} este o locație apreciată pentru evenimente speciale și ne-am dori să explorăm o posibilă colaborare de recomandare reciprocă.\n\nClienții dumneavoastră care organizează nunți sau botezuri au nevoie și de servicii foto-video profesionale. Am fi bucuroși să fim recomandați și, la rândul nostru, să vă promovăm locația clienților noștri.\n\nPortofoliu complet: ancavisuals.ro\n\nSuntem disponibili pentru o discuție oricând.\n\nCu stimă,\nEchipa AncaVisuals`,
+    emailSubject: (venueName) => `Propunere colaborare foto-video — AncaVisuals & ${venueName}`,
+    sms: () =>
+      `Bună! Suntem AncaVisuals, echipă foto-video pentru nunți și evenimente. Dorim colaborare cu locații de evenimente. Portofoliu: ancavisuals.ro`,
+  },
+  "rochii-mirese": {
+    whatsapp: (shopName) =>
+      `Bună ziua! 👋\n\nSuntem AncaVisuals, o echipă foto-video specializată în nunți.\n\nClienții care aleg rochia la ${shopName} au nevoie și de un fotograf profesionist. Ne-am dori să discutăm o posibilă colaborare de recomandare reciprocă.\n\nPortofoliul nostru: ancavisuals.ro\n\nVă mulțumim!`,
+    email: (shopName) =>
+      `Bună ziua,\n\nSuntem echipa AncaVisuals, specializați în fotografie și videografie pentru nunți.\n\nMiresele care aleg rochia la ${shopName} sunt exact clientele care au nevoie și de un fotograf de nuntă de calitate. Ne-am dori să explorăm o colaborare de recomandare reciprocă.\n\nLa rândul nostru, le vom recomanda mireselor noastre salonul dumneavoastră.\n\nPortofoliu complet: ancavisuals.ro\n\nSuntem disponibili pentru o discuție oricând.\n\nCu stimă,\nEchipa AncaVisuals`,
+    emailSubject: (shopName) => `Propunere colaborare foto-video nuntă — AncaVisuals & ${shopName}`,
+    sms: () =>
+      `Bună! Suntem AncaVisuals, foto-video nuntă. Dorim colaborare cu saloane de rochii mireasă — recomandări reciproce. Portofoliu: ancavisuals.ro`,
+  },
 };
 
 type Tab = "search" | "contacted";
@@ -76,6 +94,7 @@ export default function VenueOutreachPage() {
   const { auth } = useAuth();
   const authHeader = { Authorization: `Bearer ${auth.accessToken}` };
 
+  const [category, setCategory] = useState<Category>("venue");
   const [tab, setTab] = useState<Tab>("search");
   const [city, setCity] = useState("Cluj-Napoca");
   const [customCity, setCustomCity] = useState("");
@@ -172,6 +191,7 @@ export default function VenueOutreachPage() {
     setVenueEmails({});
     try {
       const params = new URLSearchParams();
+      params.set("category", category);
       if (keyword.trim()) {
         params.set("keyword", keyword.trim());
         if (effectiveCity) params.set("city", effectiveCity);
@@ -203,12 +223,14 @@ export default function VenueOutreachPage() {
     else setSelected(new Set(venues.map((venue) => venue.placeId)));
   };
 
+  const tpl = MESSAGE_TEMPLATES[category];
+
   const getTemplate = (venue: Venue) => {
     const base = customMessage.trim();
     if (base) return base;
-    if (activeTemplate === "whatsapp") return MESSAGE_TEMPLATES.whatsapp(venue.name);
-    if (activeTemplate === "sms") return MESSAGE_TEMPLATES.sms();
-    return MESSAGE_TEMPLATES.email(venue.name);
+    if (activeTemplate === "whatsapp") return tpl.whatsapp(venue.name);
+    if (activeTemplate === "sms") return tpl.sms();
+    return tpl.email(venue.name);
   };
 
   const toggleChannel = (ch: "whatsapp" | "email" | "sms") => {
@@ -247,7 +269,7 @@ export default function VenueOutreachPage() {
   const sendWhatsApp = (venue: Venue) => void sendViaApi(venue, "whatsapp");
 
   const sendEmail = (venue: Venue) => {
-    const subject = encodeURIComponent(MESSAGE_TEMPLATES.emailSubject(venue.name));
+    const subject = encodeURIComponent(tpl.emailSubject(venue.name));
     const body = encodeURIComponent(getTemplate(venue));
     const to = encodeURIComponent(venueEmails[venue.placeId] ?? "");
     window.open(`https://mail.google.com/mail/?view=cm&fs=1&to=${to}&su=${subject}&body=${body}`, "_blank");
@@ -287,6 +309,28 @@ export default function VenueOutreachPage() {
       <p style={{ color: "#888", fontSize: 13, marginBottom: 20 }}>
         Caută restaurante și săli de evenimente și trimite-le un mesaj de colaborare.
       </p>
+
+      {/* Category selector */}
+      <div style={{ display: "flex", gap: 8, marginBottom: 16 }}>
+        {([
+          { key: "venue", label: "🏛 Venue & Restaurante" },
+          { key: "rochii-mirese", label: "👗 Rochii Mireasă" },
+        ] as { key: Category; label: string }[]).map(({ key, label }) => (
+          <button
+            key={key}
+            onClick={() => { setCategory(key); setVenues([]); setSelected(new Set()); setVenueEmails({}); }}
+            style={{
+              padding: "8px 18px", borderRadius: 8, border: "1px solid",
+              borderColor: category === key ? "#c9a96e" : "#333",
+              background: category === key ? "#c9a96e22" : "transparent",
+              color: category === key ? "#c9a96e" : "#666",
+              fontWeight: 700, fontSize: 13, cursor: "pointer",
+            }}
+          >
+            {label}
+          </button>
+        ))}
+      </div>
 
       {/* Tabs */}
       <div style={{ display: "flex", gap: 4, marginBottom: 24, borderBottom: "1px solid #222" }}>
@@ -383,14 +427,14 @@ export default function VenueOutreachPage() {
 
                 {editingTemplate ? (
                   <textarea
-                    value={customMessage || MESSAGE_TEMPLATES[activeTemplate === "email" ? "email" : activeTemplate === "sms" ? "sms" : "whatsapp"](venues[0]?.name ?? "Locație")}
+                    value={customMessage || (activeTemplate === "sms" ? tpl.sms() : activeTemplate === "email" ? tpl.email(venues[0]?.name ?? "Locație") : tpl.whatsapp(venues[0]?.name ?? "Locație"))}
                     onChange={(e) => setCustomMessage(e.target.value)}
                     rows={8}
                     style={{ width: "100%", background: "#0f0f0f", border: "1px solid #333", borderRadius: 6, color: "#ddd", padding: 12, fontSize: 13, fontFamily: "monospace", resize: "vertical", boxSizing: "border-box" }}
                   />
                 ) : (
                   <pre style={{ background: "#0f0f0f", borderRadius: 6, padding: 12, color: "#bbb", fontSize: 12, whiteSpace: "pre-wrap", margin: 0, maxHeight: 180, overflow: "auto" }}>
-                    {MESSAGE_TEMPLATES[activeTemplate === "email" ? "email" : activeTemplate === "sms" ? "sms" : "whatsapp"](venues[0]?.name ?? "Locație")}
+                    {activeTemplate === "sms" ? tpl.sms() : activeTemplate === "email" ? tpl.email(venues[0]?.name ?? "Locație") : tpl.whatsapp(venues[0]?.name ?? "Locație")}
                   </pre>
                 )}
               </div>

--- a/src/client/pages/LocationSEO/locationData.ts
+++ b/src/client/pages/LocationSEO/locationData.ts
@@ -16,6 +16,7 @@ export interface CityData {
   nearbyAreas: string[];
   venues: string[];
   photoSpots: string[];
+  services?: ServiceType[]; // if set, only these services generate pages for this city
 }
 
 export interface ServiceData {
@@ -610,6 +611,324 @@ export const CITIES: CityData[] = [
     venues: ["saloanele locale", "hotelurile din centru", "restauranturile din zonă", "locațiile din apropiere"],
     photoSpots: ["centrul orașului", "Lacul Roșu", "Cheile Bicazului"],
   },
+
+  // --- Sate și comune lângă Oradea — doar nuntă ---
+  {
+    slug: "sanmartin-bihor",
+    name: "Sânmartin",
+    county: "Bihor",
+    description: "comună lângă Oradea, cunoscută pentru Băile Felix, cu locații de evenimente elegante și acces ușor din Oradea",
+    intro: "La nunțile din Sânmartin și Băile Felix livrăm acoperire completă foto-video, cu un ritm relaxat și cadre care valorifică locul.",
+    nearbyAreas: ["Oradea", "Băile Felix", "Tășnad", "Nojorid"],
+    venues: ["Termal Hotel", "saloanele din Băile Felix", "locațiile din zonă"],
+    photoSpots: ["Băile Felix", "zonele verzi", "locațiile elegante din stațiune"],
+    services: ["nunta"],
+  },
+  {
+    slug: "baile-felix",
+    name: "Băile Felix",
+    county: "Bihor",
+    description: "stațiune termală lângă Oradea, cu hoteluri cu săli de nunți elegante și o atmosferă relaxată pentru evenimente mari",
+    intro: "Nunțile din Băile Felix au avantajul locațiilor cu tot confortul sub un acoperiș — documentăm tot, de la pregătiri până la petrecere.",
+    nearbyAreas: ["Sânmartin", "Oradea", "Nojorid", "Biharia"],
+    venues: ["Termal Hotel", "Lotus Therm", "International Hotel", "saloanele din stațiune"],
+    photoSpots: ["parcul stațiunii", "lacurile termale", "aleile din Felix"],
+    services: ["nunta"],
+  },
+  {
+    slug: "nojorid",
+    name: "Nojorid",
+    county: "Bihor",
+    description: "comună lângă Oradea, cu acces rapid și evenimente de familie calde, potrivite pentru nunți mai restrânse sau majorate",
+    intro: "La nunțile din Nojorid și comunele din apropierea Oradei venim cu același profesionalism ca în oraș, fără costuri suplimentare.",
+    nearbyAreas: ["Oradea", "Sânmartin", "Girișu de Criș", "Biharia"],
+    venues: ["saloanele locale", "restauranturile din zonă", "locațiile din Oradea"],
+    photoSpots: ["zonele verzi din comună", "drumul spre Oradea", "locuri naturale din jur"],
+    services: ["nunta"],
+  },
+  {
+    slug: "biharia",
+    name: "Biharia",
+    county: "Bihor",
+    description: "comună cu tradiție lângă Oradea, cu nunți mari de familie și o comunitate apropiată unde contează naturalețea și sinceritatea",
+    intro: "La nunțile din Biharia documentăm cu atenție la tradiție și la momentele de familie, cu un stil discret și livrat rapid.",
+    nearbyAreas: ["Oradea", "Sântandrei", "Girișu de Criș", "Borș"],
+    venues: ["saloanele locale", "restauranturile din comună", "locațiile din Oradea"],
+    photoSpots: ["centrul comunei", "zonele verzi", "Cetatea Biharia"],
+    services: ["nunta"],
+  },
+  {
+    slug: "santandrei-bihor",
+    name: "Sântandrei",
+    county: "Bihor",
+    description: "comună lângă Oradea cu acces rapid, nunți de familie și o comunitate caldă unde contează apropierea și livrarea rapidă",
+    intro: "La nunțile din Sântandrei acoperim evenimentul complet, cu același standard ca în Oradea și fără deplasare suplimentară.",
+    nearbyAreas: ["Oradea", "Biharia", "Nojorid", "Paleu"],
+    venues: ["saloanele locale", "restauranturile din zonă", "locațiile din Oradea"],
+    photoSpots: ["centrul comunei", "zonele verzi", "împrejurimile"],
+    services: ["nunta"],
+  },
+  {
+    slug: "salonta",
+    name: "Salonta",
+    county: "Bihor",
+    description: "oraș lângă granița cu Ungaria, cu evenimente de familie mari și o comunitate unde tradițiile de nuntă sunt păstrate cu drag",
+    intro: "La nunțile din Salonta livrăm foto-video complet, cu atenție la specificul local și la momentele care fac diferența în galeria finală.",
+    nearbyAreas: ["Oradea", "Sântana", "Curtici", "Tulca"],
+    venues: ["saloanele din centru", "restauranturile locale", "locațiile din zonă"],
+    photoSpots: ["Turnul Vânătorilor", "centrul orașului", "zonele verzi"],
+    services: ["nunta"],
+  },
+  {
+    slug: "beius",
+    name: "Beiuș",
+    county: "Bihor",
+    description: "oraș la poalele Apusenilor, cu nunți de familie autentice și un cadru natural bun pentru portrete și cadre video memorabile",
+    intro: "La nunțile din Beiuș combinăm documentarea completă a evenimentului cu cadre care valorifică frumusețea zonei Apuseni.",
+    nearbyAreas: ["Oradea", "Ștei", "Vașcău", "Drăgănești"],
+    venues: ["saloanele din centru", "restauranturile locale", "locațiile din zonă"],
+    photoSpots: ["centrul orașului", "Pădurea Neagră", "zonele montane din jur"],
+    services: ["nunta"],
+  },
+
+  // --- Sate și comune lângă Arad — doar nuntă ---
+  {
+    slug: "vladimirescu",
+    name: "Vladimirescu",
+    county: "Arad",
+    description: "suburbie a Aradului cu acces rapid, unde se organizează frecvent nunți mari cu familie extinsă și tradiții puternice",
+    intro: "La nunțile din Vladimirescu și împrejurimile Aradului livrăm acoperire foto-video completă fără costuri de deplasare.",
+    nearbyAreas: ["Arad", "Șiria", "Ghioroc", "Mândruloc"],
+    venues: ["saloanele din Vladimirescu", "restauranturile locale", "locațiile din Arad"],
+    photoSpots: ["zonele verzi", "via spre Arad", "locuri din apropierea Mureșului"],
+    services: ["nunta"],
+  },
+  {
+    slug: "ghioroc",
+    name: "Ghioroc",
+    county: "Arad",
+    description: "comună cu lac și vie lângă Arad, cu nunți organizate în locații cu specific de zonă viticolă și atmosferă autentică",
+    intro: "Nunțile din Ghioroc și zona viticolă de lângă Arad au un farmec aparte — documentăm totul cu atenție la locul și la oamenii zilei.",
+    nearbyAreas: ["Arad", "Miniș", "Pauliș", "Șiria"],
+    venues: ["locațiile cu specific de vie", "saloanele din zonă", "restauranturile locale"],
+    photoSpots: ["lacul Ghioroc", "podgoriile din zonă", "peisajele viticole"],
+    services: ["nunta"],
+  },
+  {
+    slug: "paulis",
+    name: "Păuliș",
+    county: "Arad",
+    description: "comună viticolă lângă Arad cu cadre memorabile pentru nunți, podgorii frumoase și locații cu specific autentic arădean",
+    intro: "La nunțile din Păuliș valorificăm podgoriile și peisajul viticol pentru cadre memorabile, cu o documentare completă a evenimentului.",
+    nearbyAreas: ["Arad", "Ghioroc", "Miniș", "Lipova"],
+    venues: ["cramele și locațiile viticole", "saloanele din zonă", "restauranturile locale"],
+    photoSpots: ["podgoriile din Păuliș", "peisajele viticole", "zonele de deal"],
+    services: ["nunta"],
+  },
+  {
+    slug: "lipova",
+    name: "Lipova",
+    county: "Arad",
+    description: "oraș pe Mureș lângă Arad, cu tradiții puternice de nuntă și locații bune pentru evenimentele de familie mari",
+    intro: "La nunțile din Lipova documentăm complet ziua, cu atenție la tradiție și la momentele de familie care fac diferența în galeria finală.",
+    nearbyAreas: ["Arad", "Radna", "Păuliș", "Sebiș"],
+    venues: ["saloanele din centru", "restauranturile locale", "Mânăstirea Radna area"],
+    photoSpots: ["Mânăstirea Radna", "malul Mureșului", "centrul Lipovei"],
+    services: ["nunta"],
+  },
+  {
+    slug: "pecica",
+    name: "Pecica",
+    county: "Arad",
+    description: "comună mare lângă Arad cu nunți de familie extinse și o comunitate unde tradițiile sunt respectate și celebrate cu bucurie",
+    intro: "La nunțile din Pecica livrăm acoperire foto-video completă, adaptată la ritmul și la tradițiile specifice zonei de câmpie arădeane.",
+    nearbyAreas: ["Arad", "Nădlac", "Sântana", "Turnu"],
+    venues: ["saloanele locale", "restauranturile din centru", "locațiile din zonă"],
+    photoSpots: ["centrul comunei", "malul Mureșului", "zonele verzi din jur"],
+    services: ["nunta"],
+  },
+  {
+    slug: "santana-arad",
+    name: "Sântana",
+    county: "Arad",
+    description: "oraș lângă Arad cu comunitate activă și nunți mari de familie unde contează naturalețea și acoperirea completă a zilei",
+    intro: "La nunțile din Sântana documentăm cu același profesionalism ca în Arad, cu un ritm adaptat la eveniment și livrare rapidă.",
+    nearbyAreas: ["Arad", "Pecica", "Zimandu Nou", "Curtici"],
+    venues: ["saloanele din centru", "restauranturile locale", "locațiile din zonă"],
+    photoSpots: ["centrul orașului", "zonele verzi", "împrejurimile"],
+    services: ["nunta"],
+  },
+  {
+    slug: "curtici",
+    name: "Curtici",
+    county: "Arad",
+    description: "comună la granița cu Ungaria, cu nunți mari de familie și o comunitate diversă unde evenimentele sunt momente de bucurie colectivă",
+    intro: "La nunțile din Curtici venim cu acoperire completă și un stil discret, adaptat la specificul local și la dimensiunea evenimentului.",
+    nearbyAreas: ["Arad", "Nădlac", "Sântana", "Dorobanți"],
+    venues: ["saloanele locale", "restauranturile din zonă", "locațiile din Arad"],
+    photoSpots: ["centrul comunei", "zonele verzi", "împrejurimile"],
+    services: ["nunta"],
+  },
+
+  // --- Sate și comune lângă Turda — doar nuntă ---
+  {
+    slug: "mihai-viteazu",
+    name: "Mihai Viteazu",
+    county: "Cluj",
+    description: "comună lângă Turda și Cheile Turzii, cu nunți de familie și un cadru natural spectaculos în apropiere",
+    intro: "La nunțile din Mihai Viteazu combinăm documentarea completă cu cadre care valorifică proximitatea față de Cheile Turzii.",
+    nearbyAreas: ["Turda", "Câmpia Turzii", "Copăceni", "Săndulești"],
+    venues: ["saloanele locale", "locațiile din Turda", "restauranturile din zonă"],
+    photoSpots: ["Cheile Turzii", "Salina Turda", "zonele naturale din apropiere"],
+    services: ["nunta"],
+  },
+  {
+    slug: "sandulesti",
+    name: "Săndulești",
+    county: "Cluj",
+    description: "comună pitorească lângă Turda, cu nunți de familie autentice și acces facil spre Cheile Turzii pentru cadre memorabile",
+    intro: "La nunțile din Săndulești documentăm complet evenimentul și valorificăm peisajul superb din apropierea Cheilor Turzii.",
+    nearbyAreas: ["Turda", "Mihai Viteazu", "Petreștii de Jos", "Moldovenești"],
+    venues: ["saloanele locale", "locațiile din Turda", "pensiunile din zonă"],
+    photoSpots: ["Cheile Turzii", "peisajele de deal", "zonele naturale"],
+    services: ["nunta"],
+  },
+  {
+    slug: "luna-de-sus",
+    name: "Luna de Sus",
+    county: "Cluj",
+    description: "comună între Cluj și Turda, cu nunți de familie calde și acces rapid spre locațiile premium din ambele orașe",
+    intro: "La nunțile din Luna de Sus și zona dintre Cluj și Turda livrăm acoperire completă fără deplasare suplimentară.",
+    nearbyAreas: ["Turda", "Cluj-Napoca", "Câmpia Turzii", "Apahida"],
+    venues: ["saloanele locale", "locațiile din Cluj și Turda", "restauranturile din zonă"],
+    photoSpots: ["zonele verzi", "peisajele din vale", "împrejurimile"],
+    services: ["nunta"],
+  },
+  {
+    slug: "moldovenesti",
+    name: "Moldovenești",
+    county: "Cluj",
+    description: "comună de munte lângă Turda, cu nunți intime și un cadru natural autentic potrivit pentru imagini memorabile",
+    intro: "La nunțile din Moldovenești valorificăm cadrul natural al zonei de deal și documentăm complet evenimentul.",
+    nearbyAreas: ["Turda", "Săndulești", "Iara", "Petreștii de Jos"],
+    venues: ["saloanele locale", "pensiunile din zonă", "locațiile din Turda"],
+    photoSpots: ["zonele de deal și munte", "văile din jur", "peisajele naturale"],
+    services: ["nunta"],
+  },
+
+  // --- Sate și comune lângă Sibiu — doar nuntă ---
+  {
+    slug: "selimbar",
+    name: "Șelimbăr",
+    county: "Sibiu",
+    description: "comună la marginea Sibiului cu nunți elegante, locații moderne și acces rapid la tot ce oferă Sibiul pentru evenimente",
+    intro: "La nunțile din Șelimbăr livrăm acoperire completă, cu un stil curat care se potrivește locațiilor moderne din apropierea Sibiului.",
+    nearbyAreas: ["Sibiu", "Cisnădie", "Cristian", "Orlat"],
+    venues: ["saloanele moderne din zonă", "locațiile din Sibiu", "restauranturile locale"],
+    photoSpots: ["zonele verzi", "câmpul de la Șelimbăr", "vecinătatea Sibiului"],
+    services: ["nunta"],
+  },
+  {
+    slug: "cristian-sibiu",
+    name: "Cristian",
+    county: "Sibiu",
+    description: "sat săsesc autentic lângă Sibiu, cu nunți de familie și un cadru rural bine conservat potrivit pentru imagini calde",
+    intro: "La nunțile din Cristian valorificăm farmecul satelor săsești din zona Sibiului, cu o documentare discretă și naturală.",
+    nearbyAreas: ["Sibiu", "Șelimbăr", "Rășinari", "Orlat"],
+    venues: ["saloanele locale", "locațiile din Sibiu", "pensiunile din zonă"],
+    photoSpots: ["biserica fortificată", "centrul satului", "peisajele rurale din jur"],
+    services: ["nunta"],
+  },
+  {
+    slug: "rusinari",
+    name: "Rășinari",
+    county: "Sibiu",
+    description: "sat tradițional la poalele munților, cu nunți autentice și un decor natural deosebit pentru cadre memorabile",
+    intro: "La nunțile din Rășinari cadrul muntos și tradiția locului fac diferența — documentăm cu atenție la specificul autentic al zonei.",
+    nearbyAreas: ["Sibiu", "Păltiniș", "Șelimbăr", "Orlat"],
+    venues: ["saloanele locale", "locațiile din Sibiu", "pensiunile din munte"],
+    photoSpots: ["centrul satului", "Păltiniș", "peisajele montane din jur"],
+    services: ["nunta"],
+  },
+  {
+    slug: "ocna-sibiului",
+    name: "Ocna Sibiului",
+    county: "Sibiu",
+    description: "stațiune cu lacuri sărate lângă Sibiu, potrivită pentru nunți cu atmosferă relaxată și cadre naturale neobișnuite",
+    intro: "La nunțile din Ocna Sibiului valorificăm lacurile și peisajul aparte al zonei pentru cadre unice, cu o documentare completă.",
+    nearbyAreas: ["Sibiu", "Mediaș", "Copșa Mică", "Șelimbăr"],
+    venues: ["saloanele din stațiune", "locațiile din Sibiu", "restauranturile locale"],
+    photoSpots: ["lacurile sărate", "parcul stațiunii", "zonele verzi din jur"],
+    services: ["nunta"],
+  },
+  {
+    slug: "talmaciu",
+    name: "Tălmaciu",
+    county: "Sibiu",
+    description: "comună la intrarea în Defileul Oltului, cu nunți de familie și un cadru natural pitoresc pentru cadre foto memorabile",
+    intro: "La nunțile din Tălmaciu documentăm complet ziua și valorificăm peisajul superb de la intrarea în defileu.",
+    nearbyAreas: ["Sibiu", "Avrig", "Cisnădie", "Boița"],
+    venues: ["saloanele locale", "locațiile din Sibiu", "pensiunile din zonă"],
+    photoSpots: ["Defileul Oltului", "Cetatea Tălmaciului", "peisajele din zonă"],
+    services: ["nunta"],
+  },
+
+  // --- Sate și comune lângă Sebeș și Alba Iulia — doar nuntă ---
+  {
+    slug: "lancram",
+    name: "Lancrăm",
+    county: "Alba",
+    description: "sat lângă Sebeș cunoscut ca locul natal al lui Lucian Blaga, cu nunți de familie autentice și cadre rurale cu personalitate",
+    intro: "La nunțile din Lancrăm documentăm cu atenție la farmecul locului și la momentele de familie care fac ziua memorabilă.",
+    nearbyAreas: ["Sebeș", "Alba Iulia", "Petrești", "Săsciori"],
+    venues: ["saloanele din Sebeș", "locațiile din Alba Iulia", "pensiunile locale"],
+    photoSpots: ["Casa memorială Blaga", "centrul satului", "peisajele rurale"],
+    services: ["nunta"],
+  },
+  {
+    slug: "petrestii-de-jos",
+    name: "Petrești",
+    county: "Alba",
+    description: "comună lângă Sebeș cu nunți de familie calde și acces rapid spre locațiile premium din Sebeș și Alba Iulia",
+    intro: "La nunțile din Petrești livrăm acoperire completă foto-video, cu același standard ca în Sebeș, fără deplasare suplimentară.",
+    nearbyAreas: ["Sebeș", "Lancrăm", "Alba Iulia", "Cugir"],
+    venues: ["saloanele din Sebeș", "locațiile din Alba Iulia", "restauranturile locale"],
+    photoSpots: ["peisajele rurale", "zonele verzi", "împrejurimile"],
+    services: ["nunta"],
+  },
+  {
+    slug: "vintu-de-jos",
+    name: "Vințu de Jos",
+    county: "Alba",
+    description: "comună pe Mureș lângă Alba Iulia, cu nunți de familie și un cadru natural plăcut pentru portrete și cadre video",
+    intro: "La nunțile din Vințu de Jos documentăm complet evenimentul, cu atenție la familie și la momentele care fac diferența.",
+    nearbyAreas: ["Alba Iulia", "Sebeș", "Teiuș", "Șibot"],
+    venues: ["saloanele locale", "locațiile din Alba Iulia", "restauranturile din zonă"],
+    photoSpots: ["malul Mureșului", "centrul comunei", "peisajele din vale"],
+    services: ["nunta"],
+  },
+  {
+    slug: "teius",
+    name: "Teiuș",
+    county: "Alba",
+    description: "nod feroviar important în Alba, cu nunți de familie și acces rapid spre Cluj, Alba Iulia și Blaj",
+    intro: "La nunțile din Teiuș livrăm acoperire foto-video completă, cu un ritm adaptat la eveniment și livrare rapidă.",
+    nearbyAreas: ["Alba Iulia", "Blaj", "Aiud", "Vințu de Jos"],
+    venues: ["saloanele locale", "locațiile din Alba Iulia", "restauranturile din zonă"],
+    photoSpots: ["centrul orașului", "zonele verzi", "împrejurimile"],
+    services: ["nunta"],
+  },
+  {
+    slug: "galda-de-jos",
+    name: "Galda de Jos",
+    county: "Alba",
+    description: "comună viticolă între Alba Iulia și Aiud, cu nunți autentice și locații cu specific de zonă viticolă transilvăneană",
+    intro: "La nunțile din Galda de Jos valorificăm podgoriile și cadrul natural autentic pentru imagini memorabile.",
+    nearbyAreas: ["Alba Iulia", "Aiud", "Teiuș", "Meteș"],
+    venues: ["crama Jidvei area", "saloanele locale", "locațiile din Alba Iulia"],
+    photoSpots: ["podgoriile din zonă", "peisajele de deal", "centrul comunei"],
+    services: ["nunta"],
+  },
 ];
 
 export const SERVICES: ServiceData[] = [
@@ -737,8 +1056,13 @@ export function getServiceBySlug(slug: string): ServiceData | undefined {
   return SERVICES.find(s => s.slug === slug);
 }
 
+function allowedServices(city: CityData): ServiceData[] {
+  if (!city.services) return SERVICES;
+  return SERVICES.filter(s => city.services!.includes(s.slug));
+}
+
 export const CANONICAL_LOCATION_ROUTES: LocationRoute[] = CITIES.flatMap(city =>
-  SERVICES.map(service => ({
+  allowedServices(city).map(service => ({
     path: PRIMARY_KEYWORDS[0].template(service, city),
     citySlug: city.slug,
     serviceSlug: service.slug,
@@ -748,9 +1072,8 @@ export const CANONICAL_LOCATION_ROUTES: LocationRoute[] = CITIES.flatMap(city =>
 );
 
 export const ALL_LOCATION_ROUTES: LocationRoute[] = CITIES.flatMap(city =>
-  SERVICES.flatMap(service => {
+  allowedServices(city).flatMap(service => {
     const canonicalPath = PRIMARY_KEYWORDS[0].template(service, city);
-
     return [
       ...PRIMARY_KEYWORDS.map(keyword => ({
         path: keyword.template(service, city),

--- a/src/client/pages/LocationSEO/locationData.ts
+++ b/src/client/pages/LocationSEO/locationData.ts
@@ -1,4 +1,4 @@
-export type ServiceType = "nunta" | "botez" | "majorat" | "evenimente";
+export type ServiceType = "nunta" | "botez" | "majorat" | "evenimente" | "cununie-civila" | "logodna" | "corporate" | "inmormantare" | "trash-the-dress" | "save-the-date";
 
 export interface ReviewData {
   author: string;
@@ -430,6 +430,186 @@ export const CITIES: CityData[] = [
     venues: ["Palatul Brukenthal Avrig", "The Garden Events", "saloanele din zonă", "restauranturile locale"],
     photoSpots: ["Palatul Brukenthal", "grădinile domeniului", "zona Avrigului"],
   },
+  {
+    slug: "zalau",
+    name: "Zalău",
+    county: "Sălaj",
+    description:
+      "reședința județului Sălaj, cu o comunitate caldă și evenimente de familie unde contează naturalețea și acoperirea completă a zilei",
+    intro:
+      "În Zalău fotografiem și filmăm evenimente cu un stil curat și un ritm discret, potrivit pentru familii care vor imagini autentice.",
+    nearbyAreas: ["Șimleu Silvaniei", "Jibou", "Cehu Silvaniei", "Cluj-Napoca"],
+    venues: ["Grand Restaurant", "saloanele din centru", "restauranturile locale", "locațiile din zonă"],
+    photoSpots: ["centrul orașului", "Porolissum", "zonele verzi din apropiere"],
+  },
+  {
+    slug: "deva",
+    name: "Deva",
+    county: "Hunedoara",
+    description:
+      "un oraș cu Cetatea Devei ca fundal spectaculos, potrivit pentru cadre memorabile și evenimente elegante cu personalitate",
+    intro:
+      "La evenimentele din Deva valorificăm contextul unic al cetății și al orașului, cu o documentare curată și un ritm bine adaptat la ziua respectivă.",
+    nearbyAreas: ["Simeria", "Hunedoara", "Orăștie", "Brad"],
+    venues: ["Hotel Sarmis", "Colosseum Events", "Belvedere", "restauranturile din centru"],
+    photoSpots: ["Cetatea Devei", "Parcul Cetății", "centrul orașului"],
+  },
+  {
+    slug: "hunedoara",
+    name: "Hunedoara",
+    county: "Hunedoara",
+    description:
+      "un oraș cu Castelul Corvinilor în fundal, unul dintre cele mai spectaculoase decoare medievale din România pentru evenimente și ședințe foto",
+    intro:
+      "În Hunedoara cadrul istoric e puternic — îl folosim inteligent, fără să copleșim imaginile, cu accent pe emoție și pe oamenii zilei.",
+    nearbyAreas: ["Deva", "Simeria", "Călan", "Hațeg"],
+    venues: ["Castelul Corvinilor area", "saloanele din centru", "restauranturile locale", "locațiile din Deva"],
+    photoSpots: ["Castelul Corvinilor", "Parcul Dendrologic", "centrul vechi"],
+  },
+  {
+    slug: "sfantu-gheorghe",
+    name: "Sfântu Gheorghe",
+    county: "Covasna",
+    description:
+      "reședința județului Covasna, cu o comunitate vibrantă și un mix de tradiții care face evenimentele să aibă personalitate proprie",
+    intro:
+      "La evenimentele din Sfântu Gheorghe ne adaptăm natural la ritmul zilei și la specificul local, documentând cu atenție fiecare moment important.",
+    nearbyAreas: ["Târgu Secuiesc", "Covasna", "Bixad", "Brașov"],
+    venues: ["Sugás Hotel", "saloanele din centru", "restauranturile locale", "locațiile din zonă"],
+    photoSpots: ["Parcul Municipal", "centrul orașului", "zonele verzi din apropiere"],
+  },
+  {
+    slug: "miercurea-ciuc",
+    name: "Miercurea Ciuc",
+    county: "Harghita",
+    description:
+      "un oraș cu atmosferă autentică și tradiții puternice, unde evenimentele de familie au o căldură aparte și un caracter unic",
+    intro:
+      "În Miercurea Ciuc documentăm evenimentele cu respect față de tradiție și cu atenție la momentele reale, de la familie până la atmosfera locului.",
+    nearbyAreas: ["Cristuru Secuiesc", "Odorheiu Secuiesc", "Gheorgheni", "Toplița"],
+    venues: ["Főnix Hotel", "saloanele din centru", "restauranturile locale", "locațiile din zonă"],
+    photoSpots: ["centrul orașului", "Lacul Jigodin", "Parcul Municipal"],
+  },
+  {
+    slug: "odorheiu-secuiesc",
+    name: "Odorheiu Secuiesc",
+    county: "Harghita",
+    description:
+      "un oraș pitoresc cu events de familie, cadre curate și o comunitate apropiată care pune preț pe autenticitate",
+    intro:
+      "La evenimentele din Odorheiu Secuiesc venim cu o abordare discretă și autentică, concentrată pe oameni și pe emoția reală a zilei.",
+    nearbyAreas: ["Cristuru Secuiesc", "Miercurea Ciuc", "Sovata", "Sighișoara"],
+    venues: ["Târnava Hotel", "saloanele locale", "restauranturile din centru", "locațiile din zonă"],
+    photoSpots: ["centrul vechi", "Piața Primăriei", "zonele verzi din apropiere"],
+  },
+  {
+    slug: "fagaras",
+    name: "Făgăraș",
+    county: "Brașov",
+    description:
+      "un oraș cu Cetatea Făgărașului și Munții Făgăraș în fundal, potrivit pentru cadre naturale spectaculoase și evenimente cu personalitate",
+    intro:
+      "În Făgăraș avem cadrul natural și istoric la dispoziție — îl integrăm în documentare fără să distragă atenția de la oamenii zilei.",
+    nearbyAreas: ["Avrig", "Victoria", "Brașov", "Sibiu"],
+    venues: ["Cetatea Făgărașului area", "restauranturile din centru", "saloanele locale", "locațiile din zonă"],
+    photoSpots: ["Cetatea Făgărașului", "centrul orașului", "Munții Făgăraș"],
+  },
+  {
+    slug: "sinaia",
+    name: "Sinaia",
+    county: "Prahova",
+    description:
+      "perla Carpaților, cu Castelul Peleș și un decor montan spectaculos — una dintre destinațiile favorite pentru nunți de vis și ședințe foto elegante",
+    intro:
+      "La evenimentele din Sinaia mizăm pe decorul natural excepțional, pe cadre elegante și pe o documentare curată care pune în valoare locul și oamenii.",
+    nearbyAreas: ["Predeal", "Bușteni", "Azuga", "Comarnic"],
+    venues: ["Castelul Peleș area", "Palace Hotel", "Rina Sinaia", "Montana Hotel"],
+    photoSpots: ["Castelul Peleș", "Castelul Pelișor", "Parcul Dimitrie Ghica"],
+  },
+  {
+    slug: "predeal",
+    name: "Predeal",
+    county: "Brașov",
+    description:
+      "cea mai înaltă stațiune din România, cu aer de munte, peisaje curate și un ritm relaxat — ideal pentru eventos intime și ședințe foto în natură",
+    intro:
+      "În Predeal documentăm evenimente unde natura face jumătate din treabă — noi ne concentrăm pe oameni, pe lumina de munte și pe momentele autentice.",
+    nearbyAreas: ["Sinaia", "Azuga", "Brașov", "Râșnov"],
+    venues: ["Rozmarin Hotel", "Cioplea Hotel", "Cerbul", "locațiile din zonă"],
+    photoSpots: ["pârtiile și pădurile din jur", "centrul stațiunii", "Dealul Clăbucet"],
+  },
+  {
+    slug: "baia-mare",
+    name: "Baia Mare",
+    county: "Maramureș",
+    description:
+      "cel mai mare oraș din Maramureș, cu viață culturală bogată, locații bune și evenimente cu tradiție și energie proprie",
+    intro:
+      "La evenimentele din Baia Mare livrăm foto-video cu un stil curat și un ritm adaptat la programul real al zilei, de la pregătiri până la petrecere.",
+    nearbyAreas: ["Tăuții-Măgherăuș", "Baia Sprie", "Sighetu Marmației", "Cavnic"],
+    venues: ["Hotel Eurohotel", "Riviera Events", "saloanele din centru", "restauranturile locale"],
+    photoSpots: ["Piața Libertății", "Turnul Ștefan", "Parcul Municipal"],
+  },
+  {
+    slug: "satu-mare",
+    name: "Satu Mare",
+    county: "Satu Mare",
+    description:
+      "un oraș cu influențe centrale-europene, clădiri elegante și o scenă de evenimente activă, bun pentru nunți clasice și botezuri cu familie mare",
+    intro:
+      "În Satu Mare acoperim evenimente cu un stil echilibrat, curat și adaptat la ritmul familiei, cu livrare rapidă și atenție la detalii.",
+    nearbyAreas: ["Carei", "Ardud", "Negrești-Oaș", "Zalău"],
+    venues: ["Hotel Dacia", "Astoria Events", "Melody Hall", "saloanele din centru"],
+    photoSpots: ["Piața Libertății", "Turnul Pompierilor", "Parcul Dodici"],
+  },
+  {
+    slug: "petrosani",
+    name: "Petroșani",
+    county: "Hunedoara",
+    description:
+      "centrul Văii Jiului, un oraș cu comunitate puternică și evenimente de familie unde apropierea și autenticitatea sunt pe primul loc",
+    intro:
+      "La evenimentele din Petroșani venim cu o documentare sinceră, adaptată la ritmul specific al zilei și la importanța momentelor de familie.",
+    nearbyAreas: ["Vulcan", "Lupeni", "Uricani", "Deva"],
+    venues: ["saloanele din centru", "restauranturile locale", "hotelurile din zonă", "locațiile din Vale"],
+    photoSpots: ["centrul orașului", "zonele montane din jur", "Parâng"],
+  },
+  {
+    slug: "orastie",
+    name: "Orăștie",
+    county: "Hunedoara",
+    description:
+      "un oraș cu istorie dacică bogată și evenimente de familie calde, bun pentru documentare autentică și cadre naturale",
+    intro:
+      "La evenimentele din Orăștie documentăm cu atenție la specificul local și la momentele care fac ziua memorabilă pentru toată familia.",
+    nearbyAreas: ["Deva", "Simeria", "Călan", "Sebeș"],
+    venues: ["saloanele din centru", "restauranturile locale", "locațiile din zonă", "Costești area"],
+    photoSpots: ["Sarmizegetusa Regia", "centrul vechi", "zonele verzi"],
+  },
+  {
+    slug: "toplita",
+    name: "Toplița",
+    county: "Harghita",
+    description:
+      "un orășel la poalele munților, cu natură autentică și evenimente de familie cu atmosferă caldă și tradițională",
+    intro:
+      "La evenimentele din Toplița mizăm pe autenticitate, natură și cadre curate care surprind familia fără artificii inutile.",
+    nearbyAreas: ["Gheorgheni", "Reghin", "Miercurea Ciuc", "Ditrău"],
+    venues: ["saloanele locale", "restauranturile din centru", "pensiunile din zonă", "locațiile din apropiere"],
+    photoSpots: ["centrul orașului", "Parcul Mureșul", "zonele montane din jur"],
+  },
+  {
+    slug: "gheorgheni",
+    name: "Gheorgheni",
+    county: "Harghita",
+    description:
+      "un oraș din inima Harghitei, cu peisaje spectaculoase și evenimente de familie cu caracter autentic și comunitar",
+    intro:
+      "La evenimentele din Gheorgheni documentăm cu respect față de tradiție și cu atenție la momentele care fac ziua specială pentru familie.",
+    nearbyAreas: ["Toplița", "Borsec", "Ditrău", "Miercurea Ciuc"],
+    venues: ["saloanele locale", "hotelurile din centru", "restauranturile din zonă", "locațiile din apropiere"],
+    photoSpots: ["centrul orașului", "Lacul Roșu", "Cheile Bicazului"],
+  },
 ];
 
 export const SERVICES: ServiceData[] = [
@@ -472,6 +652,66 @@ export const SERVICES: ServiceData[] = [
     description:
       "Oferim foto, video și pachete complete pentru evenimente private, aniversări, petreceri restrânse și momente de familie unde contează discreția și livrarea rapidă.",
     shortPitch: "pentru clienți care vor acoperire completă foto-video și un furnizor care se adaptează ușor la tipul evenimentului",
+  },
+  {
+    slug: "cununie-civila",
+    name: "Cununie Civilă",
+    accusative: "cununia civilă",
+    plural: "cununii civile",
+    nameLong: "Fotografie și videografie pentru cununie civilă",
+    description:
+      "Cununia civilă e un moment scurt dar plin de emoție. Documentăm discret întreaga ceremonie — de la pregătiri, la semnătură, până la prima poză de cuplu.",
+    shortPitch: "pentru cupluri care vor imagini curate și emoție autentică la cununia civilă, fără pauze forțate sau cadre artificiale",
+  },
+  {
+    slug: "logodna",
+    name: "Logodnă",
+    accusative: "logodna",
+    plural: "logodne",
+    nameLong: "Fotografie și videografie pentru logodnă și inel de cerere",
+    description:
+      "Surprindem cererea în căsătorie sau ședința de logodnă cu discreție și naturalețe — cadre curate, emoție reală și imagini care spun o poveste.",
+    shortPitch: "pentru cupluri care vor să surprindă cererea în căsătorie sau să facă o ședință de logodnă cu cadre autentice",
+  },
+  {
+    slug: "corporate",
+    name: "Corporate",
+    accusative: "evenimentul corporate",
+    plural: "evenimente corporate",
+    nameLong: "Fotografie și videografie pentru evenimente corporate",
+    description:
+      "Acoperim conferințe, team building-uri, lansări de produse și evenimente de business cu un stil profesionist, discret și livrat rapid.",
+    shortPitch: "pentru companii care au nevoie de foto-video profesionist la evenimente corporate, conferințe sau activări de brand",
+  },
+  {
+    slug: "inmormantare",
+    name: "Înmormântare",
+    accusative: "înmormântarea",
+    plural: "înmormântări",
+    nameLong: "Fotografie și videografie pentru înmormântare și priveghi",
+    description:
+      "Documentăm cu maximă discreție și respect ceremoniile de înmormântare, pomenire și priveghi — pentru ca familia să păstreze amintiri dincolo de durere.",
+    shortPitch: "pentru familii care doresc o documentare discretă și respectuoasă a ceremoniei de înmormântare sau priveghi",
+  },
+  {
+    slug: "trash-the-dress",
+    name: "Trash the Dress",
+    accusative: "ședința trash the dress",
+    plural: "ședințe trash the dress",
+    nameLong: "Fotografie Trash the Dress — ședință foto după nuntă",
+    description:
+      "O ședință foto îndrăzneață cu rochia de mireasă, după nuntă — în apă, în natură sau în locații neconvenționale. Cadre curate, energie autentică.",
+    shortPitch: "pentru mirese care vor o ședință foto creativă și neconvențională cu rochia de nuntă, după marele eveniment",
+  },
+  {
+    slug: "save-the-date",
+    name: "Save the Date",
+    accusative: "ședința save the date",
+    plural: "ședințe save the date",
+    nameLong: "Fotografie Save the Date — ședință foto înainte de nuntă",
+    description:
+      "Ședința save the date e prima oară când fotografiem cuplul împreună — relaxat, natural, fără presiunea zilei mari. Cadre pentru invitații și amintiri.",
+    shortPitch: "pentru cupluri care vor o ședință foto relaxată înainte de nuntă, pentru save the date sau albumul de cuplu",
   },
 ];
 

--- a/src/client/routes/adminRoutes.tsx
+++ b/src/client/routes/adminRoutes.tsx
@@ -39,6 +39,7 @@ const WeddingHubAdminPage = loadable(() => import("../features/admin/components/
 const OfferTemplateAdminPage = loadable(() => import("../features/admin/components/OfferTemplateAdminPage"), opts);
 const OfferTemplateOrganizerPage = loadable(() => import("../features/admin/components/OfferTemplateOrganizerPage"), opts);
 const MediaAssetsAdminPage = loadable(() => import("../features/admin/components/MediaAssetsAdminPage"), opts);
+const VenueOutreachPage = loadable(() => import("../features/admin/components/VenueOutreachPage"), opts);
 
 export const adminRoutes = [
   <Route key="protected" element={<RequireAuth />}>
@@ -69,6 +70,7 @@ export const adminRoutes = [
       <Route path="/admin/instagram-proposals" element={<InstagramProposalsAdminPage />} />
       <Route path="/admin/oferte" element={<OferteAdminPage />} />
       <Route path="/admin/media-assets" element={<MediaAssetsAdminPage />} />
+      <Route path="/admin/venue-outreach" element={<VenueOutreachPage />} />
       <Route path="/admin/template-oferte" element={<OfferTemplateAdminPage />} />
       <Route path="/admin/template-oferte/:serviceId" element={<OfferTemplateOrganizerPage />} />
       <Route element={<WeddingHubAuthWrapper />}>

--- a/src/server/routes/venueOutreach.routes.ts
+++ b/src/server/routes/venueOutreach.routes.ts
@@ -1,0 +1,280 @@
+import { Router } from "express";
+import { requireFirebaseAuth, requireSupremeAdmin } from "../middleware/requireFirebaseAuth";
+import { firestore } from "../firestore";
+import { Timestamp } from "firebase-admin/firestore";
+
+const router = Router();
+router.use(requireFirebaseAuth, requireSupremeAdmin);
+
+const PLACES_KEY =
+  process.env.GOOGLE_PLACES_API ??
+  process.env.GOOGLE_PLACES_API_KEY ??
+  process.env.VITE_GOOGLE_MAPS_BROWSER_KEY ??
+  "";
+
+const LOG_COLLECTION = "venueOutreachLog";
+
+const SEARCH_QUERIES = [
+  "sală de nunți",
+  "restaurant evenimente",
+  "salon petreceri",
+  "locație nuntă",
+  "restaurant nuntă",
+];
+
+function toSlug(text: string): string {
+  return text
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/[̀-ͯ]/g, "")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+interface PlacesTextResult {
+  place_id: string;
+  name: string;
+  formatted_address: string;
+  rating?: number;
+  user_ratings_total?: number;
+  types: string[];
+}
+
+interface PlacesDetailsResult {
+  formatted_phone_number?: string;
+  international_phone_number?: string;
+  website?: string;
+}
+
+async function textSearch(query: string, city: string): Promise<PlacesTextResult[]> {
+  const encoded = encodeURIComponent(`${query} ${city}`);
+  const url = `https://maps.googleapis.com/maps/api/place/textsearch/json?query=${encoded}&language=ro&region=ro&key=${PLACES_KEY}`;
+  const response = await fetch(url);
+  const data = (await response.json()) as { results: PlacesTextResult[]; status: string };
+  if (data.status !== "OK" && data.status !== "ZERO_RESULTS") {
+    console.warn(`Places text search status: ${data.status} for "${query} ${city}"`);
+  }
+  return data.results ?? [];
+}
+
+async function fetchDetails(placeId: string): Promise<PlacesDetailsResult> {
+  const fields = "formatted_phone_number,international_phone_number,website";
+  const url = `https://maps.googleapis.com/maps/api/place/details/json?place_id=${placeId}&fields=${fields}&language=ro&key=${PLACES_KEY}`;
+  const response = await fetch(url);
+  const data = (await response.json()) as { result?: PlacesDetailsResult; status: string };
+  return data.result ?? {};
+}
+
+router.get("/venue-outreach/search", async (req, res) => {
+  const city = (req.query.city as string | undefined)?.trim();
+  const keyword = (req.query.keyword as string | undefined)?.trim();
+
+  if (!city && !keyword) {
+    res.status(400).json({ error: "city or keyword param required" });
+    return;
+  }
+
+  if (!PLACES_KEY) {
+    res.status(500).json({ error: "Google Places API key not configured" });
+    return;
+  }
+
+  try {
+    const seen = new Set<string>();
+    const venues: PlacesTextResult[] = [];
+
+    if (keyword) {
+      // Direct keyword search — use keyword as the query, city as location filter if provided
+      const queryString = city ? `${keyword} ${city}` : keyword;
+      const encoded = encodeURIComponent(queryString);
+      const url = `https://maps.googleapis.com/maps/api/place/textsearch/json?query=${encoded}&language=ro&region=ro&key=${PLACES_KEY}`;
+      const response = await fetch(url);
+      const data = (await response.json()) as { results: PlacesTextResult[]; status: string };
+      if (data.status !== "OK" && data.status !== "ZERO_RESULTS") {
+        console.warn(`Places text search status: ${data.status} for "${queryString}"`);
+      }
+      for (const place of (data.results ?? [])) {
+        if (!seen.has(place.place_id)) {
+          seen.add(place.place_id);
+          venues.push(place);
+        }
+      }
+    } else {
+      for (const query of SEARCH_QUERIES) {
+        const results = await textSearch(query, city!);
+        for (const place of results) {
+          if (!seen.has(place.place_id)) {
+            seen.add(place.place_id);
+            venues.push(place);
+          }
+        }
+      }
+    }
+
+    const withDetails = await Promise.all(
+      venues.map(async (venue) => {
+        const details = await fetchDetails(venue.place_id);
+        return {
+          placeId: venue.place_id,
+          slug: toSlug(venue.name),
+          name: venue.name,
+          address: venue.formatted_address,
+          rating: venue.rating,
+          reviewCount: venue.user_ratings_total,
+          types: venue.types,
+          phone: details.formatted_phone_number ?? details.international_phone_number ?? null,
+          website: details.website ?? null,
+        };
+      })
+    );
+
+    res.json({ venues: withDetails, city: city ?? keyword });
+  } catch (error) {
+    console.error("venue-outreach error:", error);
+    res.status(500).json({ error: "Places API request failed" });
+  }
+});
+
+router.get("/venue-outreach/extract-email", async (req, res) => {
+  const website = (req.query.website as string | undefined)?.trim();
+  if (!website) {
+    res.status(400).json({ error: "website param required" });
+    return;
+  }
+
+  try {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 5000);
+    const response = await fetch(website, {
+      signal: controller.signal,
+      headers: { "User-Agent": "Mozilla/5.0 (compatible; AncaVisuals-bot/1.0)" },
+    });
+    clearTimeout(timeout);
+
+    const html = await response.text();
+    const emailRegex = /[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}/g;
+    const found = html.match(emailRegex) ?? [];
+
+    const blacklist = ["sentry", "wixpress", "example", "schema", "pixel", "cloudflare", "jquery", "bootstrap", "fontawesome", "google", "facebook", "w3.org", "wordpress", "github"];
+    const emails = [...new Set(found)].filter(
+      (email) => !blacklist.some((b) => email.toLowerCase().includes(b))
+    );
+
+    res.json({ email: emails[0] ?? null, all: emails.slice(0, 5) });
+  } catch {
+    res.json({ email: null, all: [] });
+  }
+});
+
+router.post("/venue-outreach/send", async (req, res) => {
+  const { phone, message, channel } = req.body as {
+    phone: string;
+    message: string;
+    channel: "sms" | "whatsapp";
+  };
+
+  if (!phone || !message || !channel) {
+    res.status(400).json({ error: "phone, message, channel required" });
+    return;
+  }
+
+  const apiKey = process.env.SMSALERT_API_KEY;
+  const username = process.env.SMSALERT_USERNAME;
+  if (!apiKey || !username) {
+    res.status(500).json({ error: "SMSALERT_API_KEY or SMSALERT_USERNAME not configured" });
+    return;
+  }
+
+  const normalizedPhone = phone.startsWith("+") ? phone : `+40${phone.replace(/^0/, "")}`;
+  const basicAuth = Buffer.from(`${username}:${apiKey}`).toString("base64");
+
+  try {
+    const body: Record<string, string> = {
+      phoneNumber: normalizedPhone,
+      message,
+    };
+
+    if (channel === "whatsapp") {
+      const waSender = process.env.SMSALERT_WA_SENDER;
+      if (waSender) body.from = waSender;
+      body.channel = "whatsapp";
+    }
+
+    const response = await fetch("https://smsalert.mobi/api/v2/message/send", {
+      method: "POST",
+      headers: {
+        Authorization: `Basic ${basicAuth}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body),
+    });
+
+    const result = (await response.json()) as Record<string, unknown>;
+
+    if (!response.ok) {
+      console.error(`SMSAlert error [${channel}]:`, result);
+      res.status(response.status).json({ error: result.message ?? "SMSAlert API error", detail: result });
+      return;
+    }
+
+    res.json({ ok: true, result });
+  } catch (error) {
+    console.error("SMSAlert send error:", error);
+    res.status(500).json({ error: "Failed to send message" });
+  }
+});
+
+router.get("/venue-outreach/log", async (_req, res) => {
+  try {
+    const db = firestore();
+    const snapshot = await db.collection(LOG_COLLECTION).orderBy("sentAt", "desc").get();
+    const entries = snapshot.docs.map((doc) => ({
+      id: doc.id,
+      ...doc.data(),
+      sentAt: doc.data().sentAt instanceof Timestamp
+        ? doc.data().sentAt.toDate().toISOString()
+        : doc.data().sentAt,
+    }));
+    res.json({ entries });
+  } catch (error) {
+    console.error("venue-outreach log GET error:", error);
+    res.status(500).json({ error: "Failed to fetch log" });
+  }
+});
+
+router.post("/venue-outreach/log", async (req, res) => {
+  const { placeId, name, city, address, phone, website, channel } = req.body as {
+    placeId: string;
+    name: string;
+    city: string;
+    address?: string;
+    phone?: string | null;
+    website?: string | null;
+    channel: "whatsapp" | "email" | "sms";
+  };
+
+  if (!placeId || !name || !channel) {
+    res.status(400).json({ error: "placeId, name, channel required" });
+    return;
+  }
+
+  try {
+    const db = firestore();
+    await db.collection(LOG_COLLECTION).add({
+      placeId,
+      name,
+      city: city ?? "",
+      address: address ?? "",
+      phone: phone ?? null,
+      website: website ?? null,
+      channel,
+      sentAt: Timestamp.now(),
+    });
+    res.json({ ok: true });
+  } catch (error) {
+    console.error("venue-outreach log POST error:", error);
+    res.status(500).json({ error: "Failed to save log entry" });
+  }
+});
+
+export default router;

--- a/src/server/routes/venueOutreach.routes.ts
+++ b/src/server/routes/venueOutreach.routes.ts
@@ -14,13 +14,22 @@ const PLACES_KEY =
 
 const LOG_COLLECTION = "venueOutreachLog";
 
-const SEARCH_QUERIES = [
-  "sală de nunți",
-  "restaurant evenimente",
-  "salon petreceri",
-  "locație nuntă",
-  "restaurant nuntă",
-];
+const SEARCH_QUERIES: Record<string, string[]> = {
+  venue: [
+    "sală de nunți",
+    "restaurant evenimente",
+    "salon petreceri",
+    "locație nuntă",
+    "restaurant nuntă",
+  ],
+  "rochii-mirese": [
+    "magazin rochii mireasă",
+    "atelier rochii de mireasă",
+    "rochii nuntă",
+    "salon rochii mireasă",
+    "boutique rochii mireasă",
+  ],
+};
 
 function toSlug(text: string): string {
   return text
@@ -68,6 +77,7 @@ async function fetchDetails(placeId: string): Promise<PlacesDetailsResult> {
 router.get("/venue-outreach/search", async (req, res) => {
   const city = (req.query.city as string | undefined)?.trim();
   const keyword = (req.query.keyword as string | undefined)?.trim();
+  const category = ((req.query.category as string | undefined)?.trim()) || "venue";
 
   if (!city && !keyword) {
     res.status(400).json({ error: "city or keyword param required" });
@@ -84,7 +94,6 @@ router.get("/venue-outreach/search", async (req, res) => {
     const venues: PlacesTextResult[] = [];
 
     if (keyword) {
-      // Direct keyword search — use keyword as the query, city as location filter if provided
       const queryString = city ? `${keyword} ${city}` : keyword;
       const encoded = encodeURIComponent(queryString);
       const url = `https://maps.googleapis.com/maps/api/place/textsearch/json?query=${encoded}&language=ro&region=ro&key=${PLACES_KEY}`;
@@ -100,7 +109,8 @@ router.get("/venue-outreach/search", async (req, res) => {
         }
       }
     } else {
-      for (const query of SEARCH_QUERIES) {
+      const queries = SEARCH_QUERIES[category] ?? SEARCH_QUERIES["venue"];
+      for (const query of queries) {
         const results = await textSearch(query, city!);
         for (const place of results) {
           if (!seen.has(place.place_id)) {


### PR DESCRIPTION
- Admin page to search venues by city or keyword via Google Places API
- Send WhatsApp and SMS via SMSAlert.mobi Basic Auth API
- Email opens Gmail compose with subject/body pre-filled
- Persistent Firestore log (venueOutreachLog) to prevent duplicate outreach
- Contacted tab with channel filter (WA/SMS/Email)
- Channel toggle buttons to show/hide send buttons per row
- Phone number displayed above send buttons for verification
- 70+ cities across Transylvania, Bihor, Arad, Timiș, Maramureș
- Keyword search support (e.g. "Ballroom", "Events")
- Message templates without city reference