### PR TITLE
Fix SwipeProposalsPage scroll — lock viewport cross-browser

### DIFF
--- a/src/client/features/admin/components/SwipeProposalsPage.tsx
+++ b/src/client/features/admin/components/SwipeProposalsPage.tsx
@@ -50,6 +50,17 @@ export default function SwipeProposalsPage() {
   useEffect(() => { maxIndexReachedRef.current = maxIndexReached; }, [maxIndexReached]);
 
   useEffect(() => {
+    document.body.style.overflow = 'hidden';
+    document.body.style.position = 'fixed';
+    document.body.style.width = '100%';
+    return () => {
+      document.body.style.overflow = '';
+      document.body.style.position = '';
+      document.body.style.width = '';
+    };
+  }, []);
+
+  useEffect(() => {
     fetch("/api/instagram-proposals/admin/all", {
       headers: { Authorization: `Bearer ${auth.accessToken}` },
     })
@@ -266,7 +277,7 @@ export default function SwipeProposalsPage() {
 
   // ── Swipe UI ──────────────────────────────────────────────────────────────
   return (
-    <div className="min-h-screen bg-neutral-950 flex flex-col items-center justify-between py-6 px-4 select-none overflow-hidden">
+    <div className="h-dvh bg-neutral-950 flex flex-col items-center justify-between py-6 px-4 select-none overflow-hidden" style={{ touchAction: 'none' }}>
 
       {/* Header */}
       <div className="w-full max-w-sm flex items-center gap-3">
@@ -340,6 +351,7 @@ export default function SwipeProposalsPage() {
                   : "transform 0.42s cubic-bezier(0.45,0,0.55,1), opacity 0.42s cubic-bezier(0.45,0,0.55,1)",
                 cursor: isActive ? (isDragging ? "grabbing" : "grab") : "default",
                 userSelect: "none",
+                touchAction: isActive ? "none" : "auto",
               }}
             >
               <img


### PR DESCRIPTION
- h-dvh instead of min-h-screen so the page never exceeds the viewport
- Body scroll locked (overflow+position:fixed) while the swipe UI is mounted — required for Safari iOS which ignores overflow:hidden on child elements
- touch-action:none on container and active card to prevent browsers from intercepting vertical swipes as page scroll