### PR TITLE
Fix image sizing in SwipeProposalsPage

### DIFF
--- a/src/client/features/admin/components/SwipeProposalsPage.tsx
+++ b/src/client/features/admin/components/SwipeProposalsPage.tsx
@@ -361,7 +361,7 @@ export default function SwipeProposalsPage() {
                   display: "block",
                   width: "100%",
                   height: "auto",
-                  maxHeight: "68vh",
+                  maxHeight: "calc(100dvh - 240px)",
                   objectFit: "contain",
                   pointerEvents: "none",
                 }}


### PR DESCRIPTION
## Summary
- Imaginile nu mai sunt tăiate — înlocuit `maxHeight: 68vh` cu `calc(100dvh - 240px)` care ține cont de header + butoane + info
- Reverted `inset: 0` (care făcea imaginile prea mici) înapoi la `width: 100%`

## Test plan
- [ ] SwipeProposalsPage — pozele se văd complete, nu tăiate
- [ ] Funcționează pe ecrane mici (iPhone SE) și mari

🤖 Generated with [Claude Code](https://claude.com/claude-code)