### PR TITLE
Fix food log save error when confirming chat-analyzed meals

### DIFF
--- a/src/server/routes/health.routes.ts
+++ b/src/server/routes/health.routes.ts
@@ -502,7 +502,7 @@ router.post(
       const date = String(rawDate ?? TODAY());
       const buffer = photoBase64 ? Buffer.from(photoBase64, "base64") : null;
 
-      if (!buffer && !note) {
+      if (!buffer && !note && !rawAnalysis) {
         res.status(400).json({ error: "Adaugă o poză sau o notă." }); return;
       }
 


### PR DESCRIPTION
## Summary
- Fixed 400 error when saving food entries via the chat confirm flow
- The endpoint rejected requests without a note or photo, even when pre-analyzed data (`rawAnalysis`) was present
- Added `!rawAnalysis` to the validation condition so chat-confirmed meals can be saved

## Test plan
- [ ] Log a meal via chat (💬 Loghează masa), confirm with "Confirmă și adaugă" — should save successfully
- [ ] Verify that requests without note, photo, AND analysis still return 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)