### PR TITLE
Extract step log date from photo; show personalized kcal burned

### DIFF
--- a/src/client/features/admin/components/HealthTrackerPage.tsx
+++ b/src/client/features/admin/components/HealthTrackerPage.tsx
@@ -562,9 +562,9 @@ function readAndCompressImage(file: File, maxDim = 1200, quality = 0.82): Promis
 // ── Step Section ──────────────────────────────────────────────────────────────
 
 function StepSection({
-  userId, stepTarget, accentColor, authHeaders, t, readOnly = false,
+  userId, stepTarget, currentWeight, height, sex, age, accentColor, authHeaders, t, readOnly = false,
 }: {
-  userId: string; stepTarget: number; accentColor: string; authHeaders: Record<string, string>; t: HT; readOnly?: boolean;
+  userId: string; stepTarget: number; currentWeight: number; height: number; sex: "male" | "female"; age: number; accentColor: string; authHeaders: Record<string, string>; t: HT; readOnly?: boolean;
 }) {
   const [bank, setBank] = useState<StepBank | null>(null);
   const [todayLog, setTodayLog] = useState<ActivityLog | null>(null);
@@ -650,6 +650,10 @@ function StepSection({
             <div style={{ flex: 1 }}>
               <p style={{ fontSize: 15, fontWeight: 800, color: "#4ade80", margin: 0 }}>{todayLog.steps.toLocaleString()} pași</p>
               <p style={{ fontSize: 10, color: t.t4, margin: 0 }}>Total azi · {today}</p>
+            </div>
+            <div style={{ textAlign: "right", flexShrink: 0 }}>
+              <p style={{ fontSize: 14, fontWeight: 700, color: "#fb923c", margin: 0 }}>{stepsToKcal(todayLog.steps, currentWeight, height, sex, age).toLocaleString()} kcal</p>
+              <p style={{ fontSize: 9, color: t.t5, margin: 0 }}>arși</p>
             </div>
             {todayLog.entries && todayLog.entries.length > 0 && todayLog.entries[todayLog.entries.length - 1].photoUrl && (
               <img src={todayLog.entries[todayLog.entries.length - 1].photoUrl} alt="pași"
@@ -1491,6 +1495,10 @@ function ProfilePanel({
           <StepSection
             userId={userId}
             stepTarget={profile.stepTarget ?? 8000}
+            currentWeight={profile.currentWeight ?? 70}
+            height={profile.height ?? 170}
+            sex={profile.sex ?? "male"}
+            age={profile.age ?? 30}
             accentColor={accentColor}
             authHeaders={authHeaders}
             t={t}
@@ -1552,6 +1560,9 @@ function ProfilePanel({
             authHeaders={authHeaders}
             t={t}
             currentWeight={history.length > 0 ? history[history.length - 1].weight : (profile?.currentWeight ?? 80)}
+            height={profile?.height ?? 170}
+            sex={profile?.sex ?? "male"}
+            age={profile?.age ?? 30}
           />
         </Section>
 
@@ -1877,15 +1888,26 @@ interface PatternInsights {
   dataPoints: number;
 }
 
-function stepsToKcal(steps: number, weightKg: number): number {
-  // ~0.04 kcal per step per kg body weight (average stride ~0.75m, MET ~3.5)
-  return Math.round(steps * 0.04 * (weightKg / 70));
+function stepsToKcal(steps: number, weightKg: number, heightCm: number, sex: "male" | "female", age: number): number {
+  // Step length: validated gender factors (Tudor-Locke & Bassett), shortened after 60
+  const genderFactor = sex === "male" ? 0.415 : 0.413;
+  const ageFactor = age > 60 ? Math.max(0.88, 1 - (age - 60) * 0.005) : 1.0;
+  const stepLengthM = (heightCm / 100) * genderFactor * ageFactor;
+
+  // Estimated speed: 100 steps/min cadence × step length
+  const speedKmH = stepLengthM * 100 * 0.06;
+
+  // MET from Ainsworth Compendium 2011 (walking, flat terrain)
+  const met = speedKmH < 4.0 ? 2.8 : speedKmH < 5.0 ? 3.5 : speedKmH < 6.0 ? 4.3 : 5.0;
+
+  // Gross kcal = MET × weight(kg) × time(h), assuming 100 steps/min
+  return Math.round(met * weightKg * (steps / 6000));
 }
 
 function PatternInsightsSection({
-  userId, accentColor, authHeaders, t, currentWeight,
+  userId, accentColor, authHeaders, t, currentWeight, height, sex, age,
 }: {
-  userId: string; accentColor: string; authHeaders: Record<string, string>; t: HT; currentWeight: number;
+  userId: string; accentColor: string; authHeaders: Record<string, string>; t: HT; currentWeight: number; height: number; sex: "male" | "female"; age: number;
 }) {
   const [patterns, setPatterns] = useState<PatternInsights | null>(null);
   const [loading, setLoading] = useState(false);
@@ -1940,8 +1962,8 @@ function PatternInsightsSection({
   const directionLabel = patterns?.direction === "losing" ? "Scazi în greutate 🎯"
     : patterns?.direction === "gaining" ? "Câștigi în greutate ⚠️" : "Stagnare — ajustare necesară ⚡";
 
-  const kcalPer1000 = stepsToKcal(1000, currentWeight);
-  const kcalPer8000 = stepsToKcal(8000, currentWeight);
+  const kcalPer1000 = stepsToKcal(1000, currentWeight, height, sex, age);
+  const kcalPer8000 = stepsToKcal(8000, currentWeight, height, sex, age);
   const grPer8000 = (kcalPer8000 / 7700 * 1000).toFixed(0);
 
   return (

--- a/src/server/routes/health.routes.ts
+++ b/src/server/routes/health.routes.ts
@@ -55,25 +55,33 @@ async function uploadHealthPhoto(buffer: Buffer, userId: string, date: string): 
   return `${cdnDomain}/${storagePath}`;
 }
 
-async function extractStepsFromPhoto(buffer: Buffer): Promise<number> {
+async function extractStepsAndDateFromPhoto(buffer: Buffer): Promise<{ steps: number; date: string | null }> {
   const jpegBuffer = await sharp(buffer).jpeg({ quality: 90 }).toBuffer();
   const message = await anthropic.messages.create({
     model: "claude-haiku-4-5-20251001",
-    max_tokens: 50,
+    max_tokens: 100,
     messages: [{
       role: "user",
       content: [
         { type: "image", source: { type: "base64", media_type: "image/jpeg", data: jpegBuffer.toString("base64") } },
         {
           type: "text",
-          text: "Aceasta este o captură de ecran din aplicația Health (iPhone/Android/ceas Garmin/Samsung etc.). Extrage numărul TOTAL de pași înregistrați azi. Returnează DOAR cifra întreagă, fără text, spații sau unități. Exemplu: 8432. Dacă nu poți identifica pașii, returnează 0.",
+          text: "Aceasta este o captură de ecran din aplicația Health (iPhone/Android/ceas Garmin/Samsung etc.). Extrage numărul TOTAL de pași și data afișată în poză. Returnează DOAR un JSON cu formatul: {\"steps\":8432,\"date\":\"2025-06-15\"}. Data trebuie în format YYYY-MM-DD. Dacă nu poți identifica pașii, pune 0. Dacă nu poți identifica data, pune null.",
         },
       ],
     }],
   });
-  const rawText = message.content[0].type === "text" ? message.content[0].text.trim() : "0";
-  const steps = parseInt(rawText.replace(/[^0-9]/g, ""), 10);
-  return isNaN(steps) ? 0 : steps;
+  const rawText = message.content[0].type === "text" ? message.content[0].text.trim() : "";
+  try {
+    const cleaned = rawText.replace(/^```(?:json)?\s*/i, "").replace(/```\s*$/, "").trim();
+    const parsed = JSON.parse(cleaned) as { steps?: number; date?: string | null };
+    const steps = typeof parsed.steps === "number" && !isNaN(parsed.steps) ? parsed.steps : 0;
+    const date = typeof parsed.date === "string" && /^\d{4}-\d{2}-\d{2}$/.test(parsed.date) ? parsed.date : null;
+    return { steps, date };
+  } catch {
+    const steps = parseInt(rawText.replace(/[^0-9]/g, ""), 10);
+    return { steps: isNaN(steps) ? 0 : steps, date: null };
+  }
 }
 
 async function getStepBank(userId: string, stepTarget: number) {
@@ -208,13 +216,17 @@ router.post(
       if (!photoBase64) { res.status(400).json({ error: "Lipsește poza." }); return; }
 
       const buffer = Buffer.from(photoBase64, "base64");
-      const steps = await extractStepsFromPhoto(buffer);
+      const { steps, date: photoDate } = await extractStepsAndDateFromPhoto(buffer);
       if (steps === 0) {
         res.status(422).json({ error: "Nu am putut extrage pașii din poză. Asigură-te că ecranul e clar și numărul de pași e vizibil." });
         return;
       }
+      if (!photoDate) {
+        res.status(422).json({ error: "Nu am putut extrage data din poză. Asigură-te că data e vizibilă în captură." });
+        return;
+      }
 
-      const date = reqDate || TODAY();
+      const date = photoDate;
       const photoUrl = await uploadHealthPhoto(buffer, req.params.userId, `${date}-${Date.now()}`);
 
       const docRef = firestore().collection(ACTIVITY_COL).doc(`${req.params.userId}_${date}`);


### PR DESCRIPTION
## Summary
- Server now extracts both steps and date from the health app screenshot via Claude vision; returns 422 if either can't be identified
- Step logs are saved for the date shown in the photo, not today's date
- Kcal burned displayed in the step header after logging, calculated with the Ainsworth Compendium MET formula personalized to weight, height, sex and age

## Test plan
- [ ] Upload a step screenshot from a past date — verify it saves for that date, not today
- [ ] Upload a screenshot where date is not visible — verify 422 error is returned
- [ ] Check kcal burned display appears in the green step header after logging

🤖 Generated with [Claude Code](https://claude.com/claude-code)